### PR TITLE
Perf: replace mathematical verification of gradients with hash commitment

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ The script sizes for Groth16 are:
 
 | Curve | # public statements | Unlocking script size | Locking script size | Modulo threshold | Total |
 | ----- | ------------------- | --------------------- | ------------------- | ---------------- | ----- |
-| `BLS12-381` | 2 | ~ 59 KB | ~ 448 KB | 200B | ~ 507 KB |
-| `MNT4-753` | 1 | ~ 402 KB | ~ 567 KB | 200B | ~ 969 KB |
+| `BLS12-381` | 2 | ~ 59 KB | ~ 440 KB | 200B | ~ 499 KB |
+| `MNT4-753` | 1 | ~ 402 KB | ~ 508 KB | 200B | ~ 910 KB |
 
 Note: the unlocking script is dependent on the public statements.
 

--- a/src/zkscript/bilinear_pairings/model/miller_loop.py
+++ b/src/zkscript/bilinear_pairings/model/miller_loop.py
@@ -17,6 +17,7 @@ class MillerLoop:
         i: int,
         take_modulo: list[bool],
         positive_modulo: bool,
+        verify_gradient: bool,
         clean_constant: bool,
         gradient_doubling: StackFiniteFieldElement,
         P: StackEllipticCurvePoint,  # noqa: N803
@@ -28,10 +29,12 @@ class MillerLoop:
         there is no addition to be computed.
 
         Args:
-            i (int): The step begin performed in the computation of the Miller loop.
-            take_modulo (List[bool]): List of two booleans that declare whether to take modulos after
-                calculating the evaluations and the points doubling.
+            i (int): The step being performed in the computation of the Miller loop.
+            take_modulo (list[bool]): List of two booleans that declare whether to take modulos after
+                calculating the evaluations and the point doublings.
             positive_modulo (bool): If `True` the modulo of the result is taken positive. Defaults to `True`.
+            verify_gradient (bool): If `True` the validity of the gradients used for this step of
+                the Miller loop is verified.
             clean_constant (bool): Whether to clean the constant at the end of the execution of the
                 Miller loop.
             gradient_doubling (StackFiniteFieldElement): List of gradients needed for doubling.
@@ -86,7 +89,7 @@ class MillerLoop:
             positive_modulo=positive_modulo,
             check_constant=False,
             clean_constant=(i == 0) and clean_constant,
-            verify_gradient=True,
+            verify_gradient=verify_gradient,
             gradient=gradient_doubling,
             P=T,
             rolling_options=3,
@@ -111,6 +114,7 @@ class MillerLoop:
         i: int,
         take_modulo: list[bool],
         positive_modulo: bool,
+        verify_gradients: bool,
         clean_constant: bool,
         gradient_doubling: StackFiniteFieldElement,
         gradient_addition: StackFiniteFieldElement,
@@ -125,9 +129,11 @@ class MillerLoop:
 
         Args:
             i (int): The step begin performed in the computation of the Miller loop.
-            take_modulo (List[bool]): List of two booleans that declare whether to take modulos after
-                calculating the evaluations and the points doubling.
+            take_modulo (list[bool]): List of two booleans that declare whether to take modulos after
+                calculating the evaluations and the point doublings.
             positive_modulo (bool): If `True` the modulo of the result is taken positive. Defaults to `True`.
+            verify_gradients (bool): If `True` the validity of the gradients used for this step of
+                the Miller loop is verified.
             clean_constant (bool): Whether to clean the constant at the end of the execution of the
                 Miller loop.
             gradient_doubling (StackFiniteFieldElement): List of gradients needed for doubling.
@@ -206,7 +212,7 @@ class MillerLoop:
             positive_modulo=False,
             check_constant=False,
             clean_constant=False,
-            verify_gradient=True,
+            verify_gradient=verify_gradients,
             gradient=gradient_doubling,
             P=T,
             rolling_options=3,
@@ -220,7 +226,7 @@ class MillerLoop:
             positive_modulo=positive_modulo,
             check_constant=False,
             clean_constant=(i == 0) and clean_constant,
-            verify_gradient=True,
+            verify_gradient=verify_gradients,
             gradient=gradient_addition.shift(-self.EXTENSION_DEGREE),
             P=Q.set_negate(self.exp_miller_loop[i] == -1),
             Q=T,
@@ -245,9 +251,10 @@ class MillerLoop:
     def miller_loop(
         self,
         modulo_threshold: int,
+        positive_modulo: bool = True,
+        verify_gradients: bool = True,
         check_constant: bool | None = None,
         clean_constant: bool | None = None,
-        positive_modulo: bool = True,
     ) -> Script:
         """Evaluation of the Miller loop at points `P` and `Q`.
 
@@ -262,9 +269,10 @@ class MillerLoop:
 
         Args:
             modulo_threshold (int): Bit-length threshold. Values whose bit-length exceeds it are reduced modulo `q`.
+            positive_modulo (bool): If `True` the modulo of the result is taken positive. Defaults to `True`.
+            verify_gradients (bool): If `True` the validity of the gradients used for the Miller loop is verified.
             check_constant (bool | None): If `True`, check if `q` is valid before proceeding. Defaults to `None`.
             clean_constant (bool | None): If `True`, remove `q` from the bottom of the stack. Defaults to `None`.
-            positive_modulo (bool): If `True` the modulo of the result is taken positive. Defaults to `True`.
 
         Returns:
             Script to evaluate the Miller loop at points `P` and `Q`.
@@ -394,6 +402,7 @@ class MillerLoop:
                     i=i,
                     take_modulo=[take_modulo_miller_loop_output, take_modulo_point_multiplication],
                     positive_modulo=positive_modulo_i,
+                    verify_gradient=verify_gradients,
                     clean_constant=clean_constant_i,
                     gradient_doubling=gradient_doubling,
                     P=P,
@@ -406,6 +415,7 @@ class MillerLoop:
                     i=i,
                     take_modulo=[take_modulo_miller_loop_output, take_modulo_point_multiplication],
                     positive_modulo=positive_modulo_i,
+                    verify_gradients=verify_gradients,
                     clean_constant=clean_constant_i,
                     gradient_doubling=gradient_doubling,
                     gradient_addition=gradient_addition,

--- a/src/zkscript/bilinear_pairings/model/pairing.py
+++ b/src/zkscript/bilinear_pairings/model/pairing.py
@@ -12,6 +12,7 @@ class Pairing:
     def single_pairing(
         self,
         modulo_threshold: int,
+        verify_gradients: bool = True,
         check_constant: bool | None = None,
         clean_constant: bool | None = None,
         positive_modulo: bool = True,
@@ -30,6 +31,8 @@ class Pairing:
 
         Args:
             modulo_threshold (int): Bit-length threshold. Values whose bit-length exceeds it are reduced modulo `q`.
+            verify_gradients (bool): If `True`, the validity of the gradients used in the Miller loop is verified.
+                Defaults to `True`.
             check_constant (bool | None): If `True`, check if `q` is valid before proceeding. Defaults to `None`.
             clean_constant (bool | None): If `True`, remove `q` from the bottom of the stack. Defaults to `None`.
             positive_modulo (bool): If `True` the modulo of the result is taken positive. Defaults to `True`.
@@ -72,6 +75,7 @@ class Pairing:
         out += self.miller_loop(
             modulo_threshold=modulo_threshold,
             positive_modulo=False,
+            verify_gradients=verify_gradients,
             check_constant=False,
             clean_constant=False,
         )
@@ -115,6 +119,7 @@ class Pairing:
     def triple_pairing(
         self,
         modulo_threshold: int,
+        verify_gradients: int = 7,
         check_constant: bool | None = None,
         clean_constant: bool | None = None,
         positive_modulo: bool = True,
@@ -134,6 +139,8 @@ class Pairing:
 
         Args:
             modulo_threshold (int): Bit-length threshold. Values whose bit-length exceeds it are reduced modulo `q`.
+            verify_gradients (int): Bitmask deciding which gradients should be verified when executing the Miller loop.
+                Defaults to `7` (all the gradients are verified).
             check_constant (bool | None): If `True`, check if `q` is valid before proceeding. Defaults to `None`.
             clean_constant (bool | None): If `True`, remove `q` from the bottom of the stack. Defaults to `None`.
             positive_modulo (bool): If `True` the modulo of the result is taken positive. Defaults to `True`.
@@ -156,7 +163,11 @@ class Pairing:
         # quadratic([miller(P1,Q1) * miller(P2,Q2) * miller(P3,Q3)])^-1
         # quadratic([miller(P1,Q1) * miller(P2,Q2) * miller(P3,Q3)])
         out += self.triple_miller_loop(
-            modulo_threshold=modulo_threshold, positive_modulo=False, check_constant=False, clean_constant=False
+            modulo_threshold=modulo_threshold,
+            positive_modulo=False,
+            verify_gradients=verify_gradients,
+            check_constant=False,
+            clean_constant=False,
         )
 
         out += easy_exponentiation_with_inverse_check(

--- a/src/zkscript/bilinear_pairings/model/pairing.py
+++ b/src/zkscript/bilinear_pairings/model/pairing.py
@@ -119,7 +119,7 @@ class Pairing:
     def triple_pairing(
         self,
         modulo_threshold: int,
-        verify_gradients: int = 7,
+        verify_gradients: tuple[bool] = (True, True, True),
         check_constant: bool | None = None,
         clean_constant: bool | None = None,
         positive_modulo: bool = True,
@@ -139,8 +139,8 @@ class Pairing:
 
         Args:
             modulo_threshold (int): Bit-length threshold. Values whose bit-length exceeds it are reduced modulo `q`.
-            verify_gradients (int): Bitmask deciding which gradients should be verified when executing the Miller loop.
-                Defaults to `7` (all the gradients are verified).
+            verify_gradients (tuple[bool]): Tuple of bools detailing which of the gradients used in the Miller loop
+                should be mathematically verified. Defaults to `(True,True,True)`: all the gradients are verified.
             check_constant (bool | None): If `True`, check if `q` is valid before proceeding. Defaults to `None`.
             clean_constant (bool | None): If `True`, remove `q` from the bottom of the stack. Defaults to `None`.
             positive_modulo (bool): If `True` the modulo of the result is taken positive. Defaults to `True`.
@@ -160,8 +160,8 @@ class Pairing:
         out = verify_bottom_constant(q) if check_constant else Script()
 
         # After this, the stack is:
-        # quadratic([miller(P1,Q1) * miller(P2,Q2) * miller(P3,Q3)])^-1
-        # quadratic([miller(P1,Q1) * miller(P2,Q2) * miller(P3,Q3)])
+        # [miller(P1,Q1) * miller(P2,Q2) * miller(P3,Q3)]^-1
+        # [miller(P1,Q1) * miller(P2,Q2) * miller(P3,Q3)]
         out += self.triple_miller_loop(
             modulo_threshold=modulo_threshold,
             positive_modulo=False,

--- a/src/zkscript/bilinear_pairings/model/triple_miller_loop.py
+++ b/src/zkscript/bilinear_pairings/model/triple_miller_loop.py
@@ -17,7 +17,7 @@ class TripleMillerLoop:
         i: int,
         take_modulo: list[bool],
         positive_modulo: bool,
-        verify_gradients: int,
+        verify_gradients: tuple[bool],
         clean_constant: bool,
         gradients_doubling: list[StackFiniteFieldElement],
         P: list[StackEllipticCurvePoint],  # noqa: N803
@@ -33,8 +33,8 @@ class TripleMillerLoop:
             take_modulo (list[bool]): List of two booleans that declare whether to take modulos after
                 calculating the evaluations and the points doubling.
             positive_modulo (bool): If `True` the modulo of the result is taken positive. Defaults to `True`.
-            verify_gradients (int): Bitmask detailing which gradients used in this step of the Miller loop should
-                be verified.
+            verify_gradients (tuple[bool]): Tuple of booleans detailing which gradients should be mathematically
+                verified.
             clean_constant (bool): Whether to clean the constant at the end of the execution of the
                 Miller loop.
             gradients_doubling (list[StackFiniteFieldElement]): List of gradients needed for doubling.
@@ -128,7 +128,7 @@ class TripleMillerLoop:
             positive_modulo=positive_modulo,
             check_constant=False,
             clean_constant=False,
-            verify_gradient=verify_gradients & 1,
+            verify_gradient=verify_gradients[0],
             gradient=gradients_doubling[0],
             P=T[0],
             rolling_options=3,
@@ -142,7 +142,7 @@ class TripleMillerLoop:
             positive_modulo=positive_modulo,
             check_constant=False,
             clean_constant=False,
-            verify_gradient=(verify_gradients >> 1) & 1,
+            verify_gradient=verify_gradients[1],
             gradient=gradients_doubling[1],
             P=T[1].shift(self.N_POINTS_TWIST),
             rolling_options=3,
@@ -156,7 +156,7 @@ class TripleMillerLoop:
             positive_modulo=positive_modulo,
             check_constant=False,
             clean_constant=(i == 0) and clean_constant,
-            verify_gradient=(verify_gradients >> 2) & 1,
+            verify_gradient=verify_gradients[2],
             gradient=gradients_doubling[2],
             P=T[2].shift(2 * self.N_POINTS_TWIST),
             rolling_options=3,
@@ -174,7 +174,7 @@ class TripleMillerLoop:
         i: int,
         take_modulo: list[bool],
         positive_modulo: bool,
-        verify_gradients: int,
+        verify_gradients: tuple[bool],
         clean_constant: bool,
         gradients_doubling: list[StackFiniteFieldElement],
         gradients_addition: list[StackFiniteFieldElement],
@@ -192,8 +192,8 @@ class TripleMillerLoop:
             take_modulo (list[bool]): List of two booleans that declare whether to take modulos after
                 calculating the evaluations and the points doubling.
             positive_modulo (bool): If `True` the modulo of the result is taken positive. Defaults to `True`.
-            verify_gradients (int): Bitmask detailing which gradients used in this step of the Miller loop should
-                be verified.
+            verify_gradients (tuple[bool]): Tuple of bools detailing which gradients should be mathematically
+                verified.
             clean_constant (bool): Whether to clean the constant at the end of the execution of the
                 Miller loop.
             gradients_doubling (list[StackFiniteFieldElement]): List of gradients needed for doubling.
@@ -396,7 +396,7 @@ class TripleMillerLoop:
             positive_modulo=False,
             check_constant=False,
             clean_constant=False,
-            verify_gradient=verify_gradients & 1,
+            verify_gradient=verify_gradients[0],
             gradient=gradients_doubling[0],
             P=T[0],
             rolling_options=3,
@@ -412,7 +412,7 @@ class TripleMillerLoop:
             positive_modulo=positive_modulo,
             check_constant=False,
             clean_constant=False,
-            verify_gradient=verify_gradients & 1,
+            verify_gradient=verify_gradients[0],
             gradient=gradients_addition[0].shift(-self.EXTENSION_DEGREE),
             P=Q[0].set_negate(self.exp_miller_loop[i] == -1),
             Q=T[0].shift(-2 * self.N_POINTS_TWIST),
@@ -429,7 +429,7 @@ class TripleMillerLoop:
             positive_modulo=False,
             check_constant=False,
             clean_constant=False,
-            verify_gradient=(verify_gradients >> 1) & 1,
+            verify_gradient=verify_gradients[1],
             gradient=gradients_doubling[1],
             P=T[1].shift(self.N_POINTS_TWIST),
             rolling_options=3,
@@ -444,7 +444,7 @@ class TripleMillerLoop:
             positive_modulo=positive_modulo,
             check_constant=False,
             clean_constant=False,
-            verify_gradient=(verify_gradients >> 1) & 1,
+            verify_gradient=verify_gradients[1],
             gradient=gradients_addition[1].shift(-2 * self.EXTENSION_DEGREE),
             P=Q[1].set_negate(self.exp_miller_loop[i] == -1),
             Q=T[1].shift(-self.N_POINTS_TWIST),
@@ -459,7 +459,7 @@ class TripleMillerLoop:
             positive_modulo=False,
             check_constant=False,
             clean_constant=False,
-            verify_gradient=(verify_gradients >> 2) & 1,
+            verify_gradient=verify_gradients[2],
             gradient=gradients_doubling[2],
             P=T[2].shift(2 * self.N_POINTS_TWIST),
             rolling_options=3,
@@ -473,7 +473,7 @@ class TripleMillerLoop:
             positive_modulo=positive_modulo,
             check_constant=False,
             clean_constant=(i == 0) and clean_constant,
-            verify_gradient=(verify_gradients >> 2) & 1,
+            verify_gradient=verify_gradients[2],
             gradient=gradients_addition[2].shift(-3 * self.EXTENSION_DEGREE),
             P=Q[2].set_negate(self.exp_miller_loop[i] == -1),
             Q=T[2],
@@ -491,7 +491,7 @@ class TripleMillerLoop:
         self,
         modulo_threshold: int,
         positive_modulo: bool = True,
-        verify_gradients: int = 7,
+        verify_gradients: tuple[bool] = (True, True, True),
         check_constant: bool | None = None,
         clean_constant: bool | None = None,
     ) -> Script:
@@ -509,8 +509,8 @@ class TripleMillerLoop:
         Args:
             modulo_threshold (int): Bit-length threshold. Values whose bit-length exceeds it are reduced modulo `q`.
             positive_modulo (bool): If `True` the modulo of the result is taken positive. Defaults to `True`.
-            verify_gradients (int): Bitmask detailing which of the gradients used in the Miller loop should
-                be verified. Defaults to `7` (all the gradients are verified).
+            verify_gradients (tuple[bool]): Tuple of bools detailing which gradients should be mathematically verified.
+                Defaults to `(True,True,True)`: all the gradients are verified.
             check_constant (bool | None): If `True`, check if `q` is valid before proceeding. Defaults to `None`.
             clean_constant (bool | None): If `True`, remove `q` from the bottom of the stack. Defaults to `None`.
 

--- a/src/zkscript/bilinear_pairings/model/triple_miller_loop.py
+++ b/src/zkscript/bilinear_pairings/model/triple_miller_loop.py
@@ -17,6 +17,7 @@ class TripleMillerLoop:
         i: int,
         take_modulo: list[bool],
         positive_modulo: bool,
+        verify_gradients: int,
         clean_constant: bool,
         gradients_doubling: list[StackFiniteFieldElement],
         P: list[StackEllipticCurvePoint],  # noqa: N803
@@ -29,14 +30,16 @@ class TripleMillerLoop:
 
         Args:
             i (int): The step begin performed in the computation of the Miller loop.
-            take_modulo (list[bool]): list of two booleans that declare whether to take modulos after
+            take_modulo (list[bool]): List of two booleans that declare whether to take modulos after
                 calculating the evaluations and the points doubling.
             positive_modulo (bool): If `True` the modulo of the result is taken positive. Defaults to `True`.
+            verify_gradients (int): Bitmask detailing which gradients used in this step of the Miller loop should
+                be verified.
             clean_constant (bool): Whether to clean the constant at the end of the execution of the
                 Miller loop.
-            gradients_doubling (list[StackFiniteFieldElement]): list of gradients needed for doubling.
-            P (list[StackEllipticCurvePoint]): list of the points P needed for the evaluations.
-            T (list[StackEllipticCurvePoint]): list of the points T needed for the evaluations and the
+            gradients_doubling (list[StackFiniteFieldElement]): List of gradients needed for doubling.
+            P (list[StackEllipticCurvePoint]): List of the points P needed for the evaluations.
+            T (list[StackEllipticCurvePoint]): List of the points T needed for the evaluations and the
                 doublings. i-th step of the calculation of w*Q
 
         """
@@ -125,7 +128,7 @@ class TripleMillerLoop:
             positive_modulo=positive_modulo,
             check_constant=False,
             clean_constant=False,
-            verify_gradient=True,
+            verify_gradient=verify_gradients & 1,
             gradient=gradients_doubling[0],
             P=T[0],
             rolling_options=3,
@@ -139,7 +142,7 @@ class TripleMillerLoop:
             positive_modulo=positive_modulo,
             check_constant=False,
             clean_constant=False,
-            verify_gradient=True,
+            verify_gradient=(verify_gradients >> 1) & 1,
             gradient=gradients_doubling[1],
             P=T[1].shift(self.N_POINTS_TWIST),
             rolling_options=3,
@@ -153,7 +156,7 @@ class TripleMillerLoop:
             positive_modulo=positive_modulo,
             check_constant=False,
             clean_constant=(i == 0) and clean_constant,
-            verify_gradient=True,
+            verify_gradient=(verify_gradients >> 2) & 1,
             gradient=gradients_doubling[2],
             P=T[2].shift(2 * self.N_POINTS_TWIST),
             rolling_options=3,
@@ -171,6 +174,7 @@ class TripleMillerLoop:
         i: int,
         take_modulo: list[bool],
         positive_modulo: bool,
+        verify_gradients: int,
         clean_constant: bool,
         gradients_doubling: list[StackFiniteFieldElement],
         gradients_addition: list[StackFiniteFieldElement],
@@ -185,17 +189,19 @@ class TripleMillerLoop:
 
         Args:
             i (int): The step begin performed in the computation of the Miller loop.
-            take_modulo (list[bool]): list of two booleans that declare whether to take modulos after
+            take_modulo (list[bool]): List of two booleans that declare whether to take modulos after
                 calculating the evaluations and the points doubling.
             positive_modulo (bool): If `True` the modulo of the result is taken positive. Defaults to `True`.
+            verify_gradients (int): Bitmask detailing which gradients used in this step of the Miller loop should
+                be verified.
             clean_constant (bool): Whether to clean the constant at the end of the execution of the
                 Miller loop.
-            gradients_doubling (list[StackFiniteFieldElement]): list of gradients needed for doubling.
-            gradients_addition (list[StackFiniteFieldElement]): list of gradients needed for addition.
-            P (list[StackEllipticCurvePoint]): list of the points P needed for the evaluations.
-            Q (list[StackEllipticCurvePoint]): list of the points Q needed for the evaluations and the
+            gradients_doubling (list[StackFiniteFieldElement]): List of gradients needed for doubling.
+            gradients_addition (list[StackFiniteFieldElement]): List of gradients needed for addition.
+            P (list[StackEllipticCurvePoint]): List of the points P needed for the evaluations.
+            Q (list[StackEllipticCurvePoint]): List of the points Q needed for the evaluations and the
                 additions.
-            T (list[StackEllipticCurvePoint]): list of the points T needed for the evaluations and the
+            T (list[StackEllipticCurvePoint]): List of the points T needed for the evaluations and the
                 doublings. i-th step of the calculation of w*Q
 
         """
@@ -390,7 +396,7 @@ class TripleMillerLoop:
             positive_modulo=False,
             check_constant=False,
             clean_constant=False,
-            verify_gradient=True,
+            verify_gradient=verify_gradients & 1,
             gradient=gradients_doubling[0],
             P=T[0],
             rolling_options=3,
@@ -406,7 +412,7 @@ class TripleMillerLoop:
             positive_modulo=positive_modulo,
             check_constant=False,
             clean_constant=False,
-            verify_gradient=True,
+            verify_gradient=verify_gradients & 1,
             gradient=gradients_addition[0].shift(-self.EXTENSION_DEGREE),
             P=Q[0].set_negate(self.exp_miller_loop[i] == -1),
             Q=T[0].shift(-2 * self.N_POINTS_TWIST),
@@ -423,7 +429,7 @@ class TripleMillerLoop:
             positive_modulo=False,
             check_constant=False,
             clean_constant=False,
-            verify_gradient=True,
+            verify_gradient=(verify_gradients >> 1) & 1,
             gradient=gradients_doubling[1],
             P=T[1].shift(self.N_POINTS_TWIST),
             rolling_options=3,
@@ -438,7 +444,7 @@ class TripleMillerLoop:
             positive_modulo=positive_modulo,
             check_constant=False,
             clean_constant=False,
-            verify_gradient=True,
+            verify_gradient=(verify_gradients >> 1) & 1,
             gradient=gradients_addition[1].shift(-2 * self.EXTENSION_DEGREE),
             P=Q[1].set_negate(self.exp_miller_loop[i] == -1),
             Q=T[1].shift(-self.N_POINTS_TWIST),
@@ -453,7 +459,7 @@ class TripleMillerLoop:
             positive_modulo=False,
             check_constant=False,
             clean_constant=False,
-            verify_gradient=True,
+            verify_gradient=(verify_gradients >> 2) & 1,
             gradient=gradients_doubling[2],
             P=T[2].shift(2 * self.N_POINTS_TWIST),
             rolling_options=3,
@@ -467,7 +473,7 @@ class TripleMillerLoop:
             positive_modulo=positive_modulo,
             check_constant=False,
             clean_constant=(i == 0) and clean_constant,
-            verify_gradient=True,
+            verify_gradient=(verify_gradients >> 2) & 1,
             gradient=gradients_addition[2].shift(-3 * self.EXTENSION_DEGREE),
             P=Q[2].set_negate(self.exp_miller_loop[i] == -1),
             Q=T[2],
@@ -485,6 +491,7 @@ class TripleMillerLoop:
         self,
         modulo_threshold: int,
         positive_modulo: bool = True,
+        verify_gradients: int = 7,
         check_constant: bool | None = None,
         clean_constant: bool | None = None,
     ) -> Script:
@@ -501,12 +508,19 @@ class TripleMillerLoop:
 
         Args:
             modulo_threshold (int): Bit-length threshold. Values whose bit-length exceeds it are reduced modulo `q`.
+            positive_modulo (bool): If `True` the modulo of the result is taken positive. Defaults to `True`.
+            verify_gradients (int): Bitmask detailing which of the gradients used in the Miller loop should
+                be verified. Defaults to `7` (all the gradients are verified).
             check_constant (bool | None): If `True`, check if `q` is valid before proceeding. Defaults to `None`.
             clean_constant (bool | None): If `True`, remove `q` from the bottom of the stack. Defaults to `None`.
-            positive_modulo (bool): If `True` the modulo of the result is taken positive. Defaults to `True`.
 
         Returns:
             Script to evaluate the product of three Miller loops.
+
+        Preconditions:
+            - Pi are passed as couples of integers (minimally encoded, in little endian)
+            - Qi are passed as couples of elements in F_q^{k/d}
+            - miller(P1,Q1) * miller(P2,Q2) * miller(P3,Q3)
 
         Notes:
             At the beginning of every iteration of the loop the stack is assumed to be:
@@ -540,12 +554,6 @@ class TripleMillerLoop:
 
             Modulo operations are carried out as in a similar fashion to a single miller loop, with the only difference
             being that the update of f is now always of the form: f <-- f^2 * Dense
-        """
-        """
-        Assumption on data:
-            - Pi are passed as couples of integers (minimally encoded, in little endian)
-            - Qi are passed as couples of elements in F_q^{k/d}
-            - miller(P1,Q1) * miller(P2,Q2) * miller(P3,Q3)
         """
         gradients_addition = [
             StackFiniteFieldElement(
@@ -644,6 +652,7 @@ class TripleMillerLoop:
                     i=i,
                     take_modulo=[take_modulo_miller_loop_output, take_modulo_point_multiplication],
                     positive_modulo=positive_modulo_i,
+                    verify_gradients=verify_gradients,
                     clean_constant=clean_constant_i,
                     gradients_doubling=gradients_doubling,
                     P=P,
@@ -658,6 +667,7 @@ class TripleMillerLoop:
                     i=i,
                     take_modulo=[take_modulo_miller_loop_output, take_modulo_point_multiplication],
                     positive_modulo=positive_modulo_i,
+                    verify_gradients=verify_gradients,
                     clean_constant=clean_constant_i,
                     gradients_doubling=gradients_doubling,
                     gradients_addition=gradients_addition,

--- a/src/zkscript/groth16/model/groth16.py
+++ b/src/zkscript/groth16/model/groth16.py
@@ -222,7 +222,7 @@ class Groth16(PairingModel):
         out += self.pairing_model.triple_pairing(
             modulo_threshold=modulo_threshold,
             positive_modulo=True,
-            verify_gradients=1,
+            verify_gradients=(True, False, False),
             check_constant=False,
             clean_constant=clean_constant,
         )

--- a/src/zkscript/groth16/model/groth16.py
+++ b/src/zkscript/groth16/model/groth16.py
@@ -1,6 +1,6 @@
 """Bitcoin scripts that perform Groth16 proof verification."""
 
-from tx_engine import Script
+from tx_engine import Script, encode_num, hash256d
 
 # Pairing
 from src.zkscript.bilinear_pairings.model.model_definition import PairingModel
@@ -11,7 +11,7 @@ from src.zkscript.elliptic_curves.ec_operations_fq import EllipticCurveFq
 from src.zkscript.elliptic_curves.ec_operations_fq_unrolled import EllipticCurveFqUnrolled
 from src.zkscript.types.locking_keys.groth16 import Groth16LockingKey
 from src.zkscript.util.utility_functions import optimise_script
-from src.zkscript.util.utility_scripts import nums_to_script, roll, verify_bottom_constant
+from src.zkscript.util.utility_scripts import nums_to_script, pick, roll, verify_bottom_constant
 
 
 class Groth16(PairingModel):
@@ -35,6 +35,71 @@ class Groth16(PairingModel):
         self.curve_a = curve_a
         self.r = r
 
+    def __gradients_to_hash_commitment(self, locking_key: Groth16LockingKey) -> bytes:
+        """Construct the hash commitment for the gradients of -gamma and -delta.
+
+        Args:
+            locking_key (Groth16LockingKey): Locking key used to generate the verifier. Encapsulates the data of the
+                CRS needed by the verifier.
+        """
+        verification_hash = b""
+        for i in range(len(locking_key.gradients_pairings[0]) - 1, -1, -1):
+            for j in range(len(locking_key.gradients_pairings[0][i]) - 1, -1, -1):
+                for k in range(1, 3):
+                    verification_hash += b"".join(
+                        [
+                            hash256d(encode_num(locking_key.gradients_pairings[k][i][j][s]))
+                            for s in range(self.pairing_model.EXTENSION_DEGREE)
+                        ]
+                    )
+                    verification_hash = hash256d(verification_hash)
+
+        return verification_hash
+
+    def __verify_hash_commitment(self, locking_key: Groth16LockingKey, verification_hash: bytes) -> Script:
+        """Script that verifies that the gradients contained in `locking_key` commit to verification_hash.
+
+        Stack input:
+            - stack: [.., gradients_pairing, ..]
+
+        Stack output:
+            - stack: [.., gradients_pairing, ..] or fail
+
+        Args:
+            locking_key (Groth16LockingKey): Locking key used to generate the verifier. Encapsulates the data of the
+                CRS needed by the verifier.
+            verification_hash (bytes): The hash commitment against which we verify the gradients contained in
+                `locking_key`.
+        """
+        total_number_of_gradients = sum(
+            [
+                len(locking_key.gradients_pairings[k][i][j])
+                for k in range(3)
+                for i in range(len(locking_key.gradients_pairings[k]))
+                for j in range(len(locking_key.gradients_pairings[k][i]))
+            ]
+        )
+        position_to_pick = (
+            total_number_of_gradients
+            + 3 * self.pairing_model.N_POINTS_CURVE
+            + self.pairing_model.N_POINTS_TWIST
+            - self.pairing_model.EXTENSION_DEGREE
+        )  # position_first_gradient +1 -self.pairing_model.EXTENSION_DEGREE
+
+        out = Script.parse_string("OP_0")
+        for i in range(len(locking_key.gradients_pairings[0]) - 1, -1, -1):
+            for _ in range(len(locking_key.gradients_pairings[0][i]) - 1, -1, -1):
+                for _ in range(1, 3):
+                    for _ in range(self.pairing_model.EXTENSION_DEGREE):
+                        out += pick(position=position_to_pick, n_elements=1) + Script.parse_string("OP_HASH256 OP_CAT")
+                        position_to_pick -= 1  # Move one towards top of the stack
+                    out += Script.parse_string("OP_HASH256")
+                position_to_pick -= self.pairing_model.EXTENSION_DEGREE  # Skip gradients for B
+        out.append_pushdata(verification_hash)
+        out += Script.parse_string("OP_EQUALVERIFY")
+
+        return out
+
     def groth16_verifier(
         self,
         locking_key: Groth16LockingKey,
@@ -46,17 +111,17 @@ class Groth16(PairingModel):
         """Groth16 verifier.
 
         Stack input:
-            - stack:    [q, ..., inverse_miller_loop_triple_pairing, lambdas_pairing, A, B, C,
-                lambda[sum_(i=0)^(l-1), a_i * gamma_abc[i], a_l * gamma_abc[l]], ..., lambda[gamma_abc[0],
-                a_1 * gamma_abc[1]], a_1, lambdas[a_1,gamma_abc[1]], ..., a_l, lambdas[a_l,gamma_abc[l]]]
+            - stack:    [q, ..., inverse_miller_loop_triple_pairing, gradients_pairing, A, B, C,
+                gradient[sum_(i=0)^(l-1), a_i * gamma_abc[i], a_l * gamma_abc[l]], ..., gradient[gamma_abc[0],
+                a_1 * gamma_abc[1]], a_1, gradients[a_1,gamma_abc[1]], ..., a_l, gradients[a_l,gamma_abc[l]]]
 
                 where:
-                 - a_i lambdas[a_i,gamma_abc[i]] is the input required to execute unrolled_multiplication from
+                 - a_i gradients[a_i,gamma_abc[i]] is the input required to execute unrolled_multiplication from
                     EllipticCurveFqUnrolled (except for gamma_abc[i], which is hard coded into the script)
-                - lambda[sum_(i=0)^(j-1) a_i * gamma_abc[i], a_j * gamma_abc[j]] is the gradient through
+                - gradient[sum_(i=0)^(j-1) a_i * gamma_abc[i], a_j * gamma_abc[j]] is the gradient through
                     a_j * gamma_abc[j] and sum_(i=0)^(j-1) a_i * gamma_abc[i] to compute their sum
-                - lambdas_pairing are the lambdas needed to execute the function self.triple_pairing() (from the Pairing
-                    class) to compute the triple pairing
+                - gradients_pairing are the gradients needed to execute the method `self.triple_pairing()`
+                    (from the Pairing class) to compute the triple pairing
             - altstack: []
 
         Stack output:
@@ -86,19 +151,20 @@ class Groth16(PairingModel):
         ec_fq = EllipticCurveFq(q=self.pairing_model.MODULUS, curve_a=self.curve_a)
         # Unrolled EC arithmetic
         ec_fq_unrolled = EllipticCurveFqUnrolled(q=self.pairing_model.MODULUS, ec_over_fq=ec_fq)
+        # Hash used to verify the gradients of -gamma and -delta
+        verification_hash = self.__gradients_to_hash_commitment(locking_key=locking_key)
 
         out = verify_bottom_constant(self.pairing_model.MODULUS) if check_constant else Script()
 
-        """
-        After this:
-            - the stack is: q .. inverse_miller_loop_triple_pairing lambdas_pairing A B C
-            lambda[sum_(i=0)^(l-1) a_i * gamma_abc[i], a_l * gamma_abc[l]] ..
-            lambda[gamma_abc[0], a_1 * gamma_abc[1]] gamma_abc[0]
-            - the altstack: a_l * gamma_abc[l] ... a_1 * gamma_abc[1]
-        """
         for i in range(n_pub, -1, -1):
-            # After this, the top of the stack is: a_(i-1) lambdas[a_(i-1),gamma_abc[i-1]],
-            # altstack = [..., a_i * gamma_abc[i]]
+            # stack in:     [q, ..., inverse_miller_loop_triple_pairing, gradients_pairing, A, B, C,
+            #                   gradient[sum_(i=0)^(l-1), a_i * gamma_abc[i], a_l * gamma_abc[l]], ...,
+            #                       gradient[gamma_abc[0], a_1 * gamma_abc[1]], a_1, gradients[a_1,gamma_abc[1]], ...,
+            #                           a_l, gradients[a_l,gamma_abc[l]]]
+            # stack out:    [q, ..., inverse_miller_loop_triple_pairing, gradients_pairing, A, B, C,
+            #                   gradient[sum_(i=0)^(l-1), a_i * gamma_abc[i], a_l * gamma_abc[l]], ...,
+            #                       gradient[gamma_abc[0], a_1 * gamma_abc[1]], gamma_abc[0]]
+            # altstack out: [a[l] * gamma_abc[l], .., a[1] * gamma_abc[1]]
             if not any(locking_key.gamma_abc[i]):
                 out += Script.parse_string(" ".join(["0x00"] * self.pairing_model.N_POINTS_CURVE))
             else:
@@ -115,16 +181,30 @@ class Groth16(PairingModel):
                 out += Script.parse_string("OP_2SWAP OP_2DROP")  # Drop gamma_abc[i]
                 out += Script.parse_string(" ".join(["OP_TOALTSTACK"] * self.pairing_model.N_POINTS_CURVE))
 
-        # After this, the stack is: q .. lambdas_pairing inverse_miller_loop_triple_pairing A B C
-        # sum_(i=0)^l a_i * gamma_abc[i]
-        for _i in range(n_pub):
+        # stack in:     [q, ..., inverse_miller_loop_triple_pairing, gradients_pairing, A, B, C,
+        #                   gradient[sum_(i=0)^(l-1), a_i * gamma_abc[i], a_l * gamma_abc[l]], ...,
+        #                       gradient[gamma_abc[0], a_1 * gamma_abc[1]], gamma_abc[0]]
+        # altstack in:  [a[l] * gamma_abc[l], .., a[1] * gamma_abc[1]]
+        # stack out:    [q, ..., inverse_miller_loop_triple_pairing, gradients_pairing, A, B, C,
+        #                   sum_(i=0)^l a_i * gamma_abc[i]]
+        # altstack out: []
+        for _ in range(n_pub):
             out += Script.parse_string(" ".join(["OP_FROMALTSTACK"] * self.pairing_model.N_POINTS_CURVE))
             out += ec_fq.point_addition_with_unknown_points(
                 take_modulo=True, positive_modulo=False, check_constant=False, clean_constant=False
             )
 
-        # After this, the stack is: q .. lambdas_pairing inverse_miller_loop_triple_pairing A
-        # sum_(i=0)^l a_i * gamma_abc[i] C B gamma delta
+        # Verify that the gradients supplied for -gamma and -delta are the correct one
+        # stack in:  [q, ..., inverse_miller_loop_triple_pairing, gradients_pairing, A, B, C,
+        #                   sum_(i=0)^l a_i * gamma_abc[i]]
+        # stack out: [q, ..., inverse_miller_loop_triple_pairing, gradients_pairing, A, B, C,
+        #                   sum_(i=0)^l a_i * gamma_abc[i]] or fail
+        out += self.__verify_hash_commitment(locking_key=locking_key, verification_hash=verification_hash)
+
+        # stack in:  [q, ..., inverse_miller_loop_triple_pairing, gradients_pairing, A, B, C,
+        #                   sum_(i=0)^l a_i * gamma_abc[i]]
+        # stack out: [q, ..., inverse_miller_loop_triple_pairing, gradients_pairing, A,
+        #                   sum_(i=0)^l a_i * gamma_abc[i], C, B, -gamma, -delta]
         out += roll(
             position=2 * self.pairing_model.N_POINTS_CURVE - 1, n_elements=self.pairing_model.N_POINTS_CURVE
         )  # Roll C
@@ -135,13 +215,19 @@ class Groth16(PairingModel):
         out += nums_to_script(locking_key.minus_gamma)
         out += nums_to_script(locking_key.minus_delta)
 
-        # After this, the stack is: q .. e(A,B) * e(sum_(i=0)^(l) a_i * gamma_abc[i], gamma) * e(C, delta)
+        # Compute the triple pairing
+        # stack in:  [q, ..., inverse_miller_loop_triple_pairing, gradients_pairing, A,
+        #                   sum_(i=0)^l a_i * gamma_abc[i], C, B, -gamma, -delta]
+        # stack out: [q, ..., pairing(A,B) * pairing(sum_(i=0)^(l) a_i * gamma_abc[i], -gamma) * pairing(C, -delta)]
         out += self.pairing_model.triple_pairing(
-            modulo_threshold=modulo_threshold, positive_modulo=True, check_constant=False, clean_constant=clean_constant
+            modulo_threshold=modulo_threshold,
+            positive_modulo=True,
+            verify_gradients=1,
+            check_constant=False,
+            clean_constant=clean_constant,
         )
 
-        # After this, the top of the stack is:
-        # [e(A,B) * e(sum_(i=0)^(l) a_i * gamma_abc[i], gamma) * e(C, delta) ?= alpha_beta]
+        # Verify pairing(A,B) * pairing(sum_(i=0)^(l) a_i * gamma_abc[i], -gamma) * pairing(C, -delta) == alpha_beta
         for ix, el in enumerate(locking_key.alpha_beta[::-1]):
             out += nums_to_script([el])
             if ix != len(locking_key.alpha_beta) - 1:

--- a/src/zkscript/types/locking_keys/groth16.py
+++ b/src/zkscript/types/locking_keys/groth16.py
@@ -15,9 +15,15 @@ class Groth16LockingKey:
             must compute
                 gamma_abc[0] + \sum_{i >= 1} pub[i-1] * gamma_abc[i]
             where pub[i] is is i-th public statement.
+        gradients_pairings (list[list[list[list[int]]]]): list of gradients required to compute the pairings
+            in the Groth16 verification equation. The meaning of the lists is:
+                - gradients_pairings[0]: gradients required to compute w*B
+                - gradients_pairings[1]: gradients required to compute w*(-gamma)
+                - gradients_pairings[2]: gradients required to compute w*(-delta)
     """
 
     alpha_beta: list[int]
     minus_gamma: list[int]
     minus_delta: list[int]
     gamma_abc: list[list[int]]
+    gradients_pairings: list[list[list[list[int]]]]

--- a/src/zkscript/types/unlocking_keys/groth16.py
+++ b/src/zkscript/types/unlocking_keys/groth16.py
@@ -1,7 +1,6 @@
 """Unlocking key for Groth16."""
 
 from dataclasses import dataclass
-from math import log2
 
 from tx_engine import Script
 
@@ -18,16 +17,18 @@ class Groth16UnlockingKey:
         A (list[int]): Component of the zk proof.
         B (list[int]): Component of the zk proof.
         C (list[int]): Component of the zk proof.
-        gradients_pairings (list[list[list[int]]]): list of gradients required to compute the pairings
+        gradients_pairings (list[list[list[list[int]]]]): list of gradients required to compute the pairings
             in the Groth16 verification equation. The meaning of the lists is:
                 - gradients_pairings[0]: gradients required to compute w*B
                 - gradients_pairings[1]: gradients required to compute w*(-gamma)
                 - gradients_pairings[2]: gradients required to compute w*(-delta)
         inverse_miller_loop (list[int]): the inverse of
             miller(A,B) * miller(gamma_abc[0] + \sum_{i >=0} pub[i-1] * gamma_abc[i], -gamma) * miller(C, -delta)
-        gradients_partial_sums (list[int]): gradients_partial_sums[n_pub - i - 1] is the gradient required to compute
-            the sum (gamma_abc[0] + \sum_{j=1}^{i} pub[j-1] gamma_abc[j]) + (pub[i] * gamma_abc[i+1]), 0 <= i <= n_pub-1
-        gradients_multiplication (list[list[list[int]]]): gradients_multiplication[i] is the list of
+        gradients_partial_sums (list[list[list[list[int]]]]): gradients_partial_sums[n_pub - i - 1] is the gradient
+            required to compute the sum
+                (gamma_abc[0] + \sum_{j=1}^{i} pub[j-1] gamma_abc[j]) + (pub[i] * gamma_abc[i+1])
+            where 0 <= i <= n_pub-1
+        gradients_multiplication (list[list[list[list[int]]]]): gradients_multiplication[i] is the list of
             gradients required to compute pub[i] * gamma_abc[i+1], 0 <= i <= n_pub-1
     """
 
@@ -35,10 +36,10 @@ class Groth16UnlockingKey:
     A: list[int]
     B: list[int]
     C: list[int]
-    gradients_pairings: list[list[list[int]]]
+    gradients_pairings: list[list[list[list[int]]]]
     inverse_miller_output: list[int]
-    gradients_partial_sums: list[int]
-    gradients_multiplication: list[list[list[int]]]
+    gradients_partial_sums: list[list[list[list[int]]]]
+    gradients_multiplication: list[list[list[list[int]]]]
 
     def to_unlocking_script(
         self,
@@ -78,7 +79,7 @@ class Groth16UnlockingKey:
 
         # Multiplications pub[i] * gamma_abc[i+1]
         for i in range(n_pub):
-            M = int(log2(groth16_model.r)) if max_multipliers is None else int(log2(self.max_multipliers[i]))
+            M = groth16_model.r.bit_length() - 1 if max_multipliers is None else max_multipliers[i].bit_length() - 1
 
             if self.pub[i] == 0:
                 out += Script.parse_string("OP_1") + Script.parse_string(" ".join(["OP_0"] * M))

--- a/tests/groth16/test_groth16.py
+++ b/tests/groth16/test_groth16.py
@@ -311,7 +311,6 @@ def save_scripts(lock, unlock, save_to_json_folder, filename, test_name):
             json.dump(data, f, indent=4)
 
 
-"""
 @pytest.mark.parametrize(
     ("test_script", "vk", "alpha_beta", "groth16_proof", "max_multipliers", "filename"),
     [
@@ -392,7 +391,6 @@ def test_groth16(test_script, vk, alpha_beta, groth16_proof, max_multipliers, fi
 
     if save_to_json_folder:
         save_scripts(str(lock), str(unlock), save_to_json_folder, filename, "groth16")
-"""
 
 
 @pytest.mark.slow

--- a/tests/groth16/test_groth16.py
+++ b/tests/groth16/test_groth16.py
@@ -311,6 +311,7 @@ def save_scripts(lock, unlock, save_to_json_folder, filename, test_name):
             json.dump(data, f, indent=4)
 
 
+"""
 @pytest.mark.parametrize(
     ("test_script", "vk", "alpha_beta", "groth16_proof", "max_multipliers", "filename"),
     [
@@ -391,13 +392,14 @@ def test_groth16(test_script, vk, alpha_beta, groth16_proof, max_multipliers, fi
 
     if save_to_json_folder:
         save_scripts(str(lock), str(unlock), save_to_json_folder, filename, "groth16")
+"""
 
 
 @pytest.mark.slow
 @pytest.mark.parametrize(
     ("alpha_beta", "vk", "groth16_proof", "test_script", "filename", "max_multipliers", "is_minimal_example"),
     [
-        *generate_test_cases(test_num=1, is_minimal_example=False, rnd_seed=42),
+        # *generate_test_cases(test_num=1, is_minimal_example=False, rnd_seed=42),
         *generate_test_cases(test_num=1, is_minimal_example=True, rnd_seed=42),
     ],
 )
@@ -446,11 +448,9 @@ def test_groth16_slow(
 
     if is_minimal_example:
         sys.stdout.write(
-            "\nThe locking script size for Groth16 for the curve" + f"{filename}" + "with" + "two"
-            if filename == "bls12_381"
-            else "one" + "public" + "inputs"
-            if filename == "bls12_381"
-            else "input" + "is" + f"{len(lock.raw_serialize())}" + "bytes."
+            f"\nThe locking script size for Groth16 for the curve {filename} with { \
+                "two public inputs" if filename == "bls12_381" else "one public input" \
+                } is {len(lock.raw_serialize())} bytes.\t"
         )
 
     if save_to_json_folder:


### PR DESCRIPTION
Changes include:
* Replace mathematical verification of gradients in Miller loop for Groth16 with hash based verification
* Set up of tests for `max_multipliers` in `unrolled_ec_multiplication` and `groth16_verifier`

Changes save 8KB in BLS12-381 (modulo threshold 200B, 2 public statements) and 60KB in MNT4-753 (modulo threshold 200B, 1 public statement)