### PR TITLE
Feat: transaction introspection

### DIFF
--- a/src/zkscript/bilinear_pairings/bls12_381/line_functions.py
+++ b/src/zkscript/bilinear_pairings/bls12_381/line_functions.py
@@ -4,8 +4,8 @@ from tx_engine import Script
 
 from src.zkscript.bilinear_pairings.bls12_381.fields import fq2_script
 from src.zkscript.types.stack_elements import StackEllipticCurvePoint, StackFiniteFieldElement
-from src.zkscript.util.utility_functions import bitmask_to_boolean_list, bool_to_moving_function, check_order
-from src.zkscript.util.utility_scripts import mod, move, pick, roll, verify_bottom_constant
+from src.zkscript.util.utility_functions import bitmask_to_boolean_list, check_order
+from src.zkscript.util.utility_scripts import bool_to_moving_function, mod, move, pick, roll, verify_bottom_constant
 
 
 class LineFunctions:

--- a/src/zkscript/bilinear_pairings/mnt4_753/line_functions.py
+++ b/src/zkscript/bilinear_pairings/mnt4_753/line_functions.py
@@ -4,8 +4,8 @@ from tx_engine import Script
 
 from src.zkscript.bilinear_pairings.mnt4_753.fields import fq2_script
 from src.zkscript.types.stack_elements import StackEllipticCurvePoint, StackFiniteFieldElement
-from src.zkscript.util.utility_functions import bitmask_to_boolean_list, bool_to_moving_function, check_order
-from src.zkscript.util.utility_scripts import mod, move, pick, roll, verify_bottom_constant
+from src.zkscript.util.utility_functions import bitmask_to_boolean_list, check_order
+from src.zkscript.util.utility_scripts import bool_to_moving_function, mod, move, pick, roll, verify_bottom_constant
 
 
 class LineFunctions:

--- a/src/zkscript/elliptic_curves/ec_operations_fq.py
+++ b/src/zkscript/elliptic_curves/ec_operations_fq.py
@@ -3,8 +3,16 @@
 from tx_engine import Script
 
 from src.zkscript.types.stack_elements import StackEllipticCurvePoint, StackFiniteFieldElement
-from src.zkscript.util.utility_functions import bitmask_to_boolean_list, bool_to_moving_function, check_order
-from src.zkscript.util.utility_scripts import mod, move, nums_to_script, pick, roll, verify_bottom_constant
+from src.zkscript.util.utility_functions import bitmask_to_boolean_list, check_order
+from src.zkscript.util.utility_scripts import (
+    bool_to_moving_function,
+    mod,
+    move,
+    nums_to_script,
+    pick,
+    roll,
+    verify_bottom_constant,
+)
 
 
 class EllipticCurveFq:

--- a/src/zkscript/elliptic_curves/ec_operations_fq2.py
+++ b/src/zkscript/elliptic_curves/ec_operations_fq2.py
@@ -3,8 +3,16 @@
 from tx_engine import Script
 
 from src.zkscript.types.stack_elements import StackEllipticCurvePoint, StackFiniteFieldElement
-from src.zkscript.util.utility_functions import bitmask_to_boolean_list, bool_to_moving_function, check_order
-from src.zkscript.util.utility_scripts import mod, move, nums_to_script, pick, roll, verify_bottom_constant
+from src.zkscript.util.utility_functions import bitmask_to_boolean_list, check_order
+from src.zkscript.util.utility_scripts import (
+    bool_to_moving_function,
+    mod,
+    move,
+    nums_to_script,
+    pick,
+    roll,
+    verify_bottom_constant,
+)
 
 
 class EllipticCurveFq2:

--- a/src/zkscript/transaction_introspection/__init__.py
+++ b/src/zkscript/transaction_introspection/__init__.py
@@ -1,0 +1,14 @@
+"""transaction_introspection package.
+
+This package provides modules for constructing Bitcoin scripts that achieve transaction introspection.
+
+Modules:
+    - transaction_introspection: Contains the TransactionIntrospection class for scripts that achieve
+        transaction introspection.
+
+Usage example:
+    >>> from tx_engine import SIGHASH
+    >>> from src.zkscript.transaction_introspection.transaction_introspection import TransactionIntrospection
+    >>>
+    >>> pushtx_script = TransactionIntrospection.pushtx(sighash=SIGHASH.ALL)
+"""

--- a/src/zkscript/transaction_introspection/__init__.py
+++ b/src/zkscript/transaction_introspection/__init__.py
@@ -10,5 +10,5 @@ Usage example:
     >>> from tx_engine import SIGHASH
     >>> from src.zkscript.transaction_introspection.transaction_introspection import TransactionIntrospection
     >>>
-    >>> pushtx_script = TransactionIntrospection.pushtx(sighash=SIGHASH.ALL)
+    >>> pushtx_script = TransactionIntrospection.pushtx(sighash_value=SIGHASH.ALL_FORKID)
 """

--- a/src/zkscript/transaction_introspection/__init__.py
+++ b/src/zkscript/transaction_introspection/__init__.py
@@ -1,10 +1,10 @@
 """transaction_introspection package.
 
-This package provides modules for constructing Bitcoin scripts that achieve transaction introspection.
+This package provides modules for constructing Bitcoin scripts for transaction introspection.
 
 Modules:
     - transaction_introspection: Contains the TransactionIntrospection class for scripts that achieve
-        transaction introspection.
+        transaction introspection. Reference for implementation: https://hackmd.io/@federicobarbacovi/By6zkFmfyl
 
 Usage example:
     >>> from tx_engine import SIGHASH

--- a/src/zkscript/transaction_introspection/transaction_introspection.py
+++ b/src/zkscript/transaction_introspection/transaction_introspection.py
@@ -1,0 +1,309 @@
+from typing import Union
+
+from tx_engine import SIGHASH, Script, Tx, hash256d
+from tx_engine import sig_hash_preimage as tx_to_sig_hash_preimage
+from tx_engine.engine.util import GROUP_ORDER_INT, Gx, Gx_bytes
+
+from src.zkscript.types.stack_elements import StackBaseElement
+from src.zkscript.util.utility_functions import bool_to_moving_function
+from src.zkscript.util.utility_scripts import ensure_is_positive, move, nums_to_script, pick, reverse_endianness, roll
+
+pushtx_bit_shift_data = {
+    2: {
+        "signature_prefix": bytes.fromhex("3045022100"),
+        "R": bytes.fromhex("02e493dbf1c10d80f3581e4904930b1404cc6c13900ee0758474fa94abe8c4cd13"),
+        "P": bytes.fromhex("034218426b38c75b706db9010aad7795fd05b872060921c048d9a679d8878c7660"),
+    },
+    3: {
+        "signature_prefix": bytes.fromhex("30440220"),
+        "R": bytes.fromhex("022f01e5e15cca351daff3843fb70f3c2f0a1bdd05e5af888a67784ef3e10a2a01"),
+        "P": bytes.fromhex("03ad36fad55727ebf76f8af96c7c2df9a298dc21d6c15269fdedfd47a70b327637"),
+    },
+}
+
+
+class TransactionIntrospection:
+    @staticmethod
+    def pushtx(
+        sighash_value: SIGHASH,
+        sig_hash_preimage: StackBaseElement = StackBaseElement(0),  # noqa: B008
+        rolling_option: int = 1,
+        clean_constants: bool = True,
+        verify_constants: bool = True,
+        is_checksigverify: bool = True,
+        is_opcodeseparator: bool = False,
+    ) -> Script:
+        """Construct PUSHTX locking script.
+
+        Stack input:
+            - stack:    [GROUP_ORDER_INT, Gx, Gx_bytes, .., sig_hash_preimage, ..]
+            - altstack: []
+        Stack output:
+            - stack:    [{GROUP_ORDER_INT}, {Gx}, {Gx_bytes}, .., {sig_hash_preimage}, ..] or fail
+            - altstack: []
+
+        Args:
+            sighash_value (SIGHASH): Sighash flag with which the message should be constructed
+            sig_hash_preimage (StackBaseElement): Position in the stack of the sig_hash_preimage.
+                Defaults to StackBaseElement(0) (on top of the stack).
+            rolling_option (int): Whether to roll or pick sig_hash_preimage. Defaults to `1` (roll).
+            clean_constants (bool): Whether to clean the constants needed for the script:
+                GROUP_ORDER_INT, Gx, Gx_bytes. Defaults to `True`.
+            verify_constants (bool): Whether or not to verify the constants used for the script.
+            is_checksigverify (bool): Whether to execute OP_CHECKSIGVERIFY or OP_CHECKSIG. Defaults
+                to `True` (OP_CHECKSIGVERIFY).
+            is_opcodeseparator (bool): Whether to prepend the signature verification with an
+                OP_CODESEPARATOR (so that the code of pushtx is not signed). Defaults to `False`.
+
+        Returns:
+            The Bitcoin Script of PUSHTX, which fails unless sig_hash_preimage is the message digest of the
+            transaction in which the script is executed. The message digest of a transactionis defined here:
+            https://github.com/bitcoin-sv/bitcoin-sv/blob/master/doc/abc/replay-protected-sighash.md#digest-algorithm
+
+        """
+
+        out = Script()
+
+        if verify_constants:
+            out += nums_to_script([GROUP_ORDER_INT, Gx])
+            out.append_pushdata(Gx_bytes)
+            for i in range(3, 0, -1):
+                out += pick(position=-i, n_elements=1)
+                out += Script.parse_string("OP_EQUALVERIFY")
+
+        # stack in:  [GROUP_ORDER_INT, Gx, Gx_bytes, .., sig_hash_preimage, ..]
+        # stack out: [GROUP_ORDER_INT, Gx, {Gx_bytes}, .., sig_hash_preimage, ..,
+        #               Gx_bytes, 0x0220||Gx_bytes||02]
+        out.append_pushdata(bytes.fromhex("0220"))
+        out += (
+            roll(position=-3, n_elements=1) if clean_constants else pick(position=-3, n_elements=1)
+        )  # Move 0x0220||Gx_bytes||02
+        out += Script.parse_string("OP_TUCK 0x02 OP_CAT OP_CAT")
+
+        # stack in:  [GROUP_ORDER_INT, Gx, {Gx_bytes}, .., sig_hash_preimage, ..,
+        #               Gx_bytes, 0x0220||Gx_bytes||02]
+        # stack out: [GROUP_ORDER_INT, Gx, {Gx_bytes}, .., {sig_hash_preimage}, ..,
+        #               Gx_bytes, 0x0220||Gx_bytes||02, h]
+        out += move(sig_hash_preimage.shift(2), bool_to_moving_function(rolling_option))
+        out += Script.parse_string("OP_HASH256") + reverse_endianness(32) + ensure_is_positive()
+
+        # Compute the s part of the signature
+        # stack in:  [GROUP_ORDER_INT, Gx, {Gx_bytes}, .., {sig_hash_preimage}, ..,
+        #               Gx_bytes, 0x0220||Gx_bytes||02, h]
+        # stack out: [{GROUP_ORDER_INT}, {Gx}, {Gx_bytes}, .., {sig_hash_preimage}, ..,
+        #               Gx_bytes, 0x0220||Gx_bytes||02, GROUP_ORDER_INT, (h + Gx) % GROUP_ORDER_INT]
+        out += roll(position=-2, n_elements=1) if clean_constants else pick(position=-2, n_elements=1)  # Move Gx
+        out += Script.parse_string("OP_ADD")
+        out += (
+            roll(position=-1, n_elements=1) if clean_constants else pick(position=-1, n_elements=1)
+        )  # Move GROUP_ORDER_INT
+        out += Script.parse_string("OP_TUCK OP_MOD")
+
+        # stack in:  [{GROUP_ORDER_INT}, {Gx}, {Gx_bytes}, .., {sig_hash_preimage}, ..,
+        #               Gx_bytes, 0x0220||Gx_bytes||02 GROUP_ORDER_INT, (h + Gx) % GROUP_ORDER_INT]
+        # stack out: [{GROUP_ORDER_INT}, {Gx}, {Gx_bytes}, .., {sig_hash_preimage}, ..,
+        #               Gx_bytes, 0x0220||Gx_bytes||02, LittleEndian(s)]
+        out += Script.parse_string(
+            "OP_DUP OP_ROT OP_TUCK OP_2 OP_DIV OP_GREATERTHAN OP_IF OP_SWAP OP_SUB OP_ELSE OP_DROP OP_ENDIF"
+        )
+
+        # stack in:  [{GROUP_ORDER_INT}, {Gx}, {Gx_bytes}, .., {sig_hash_preimage}, ..,
+        #               Gx_bytes, 0x0220||Gx_bytes||02, LittleEndian(s)]
+        # stack out: [{GROUP_ORDER_INT}, {Gx}, {Gx_bytes}, .., {sig_hash_preimage}, ..,
+        #               Gx_bytes, 0x0220||Gx_bytes||02, s]
+        out += Script.parse_string("OP_SIZE OP_SWAP 32 OP_NUM2BIN")
+        out += reverse_endianness(32)
+        out += Script.parse_string("0x20 OP_ROT OP_SUB OP_SPLIT OP_NIP")
+
+        # stack in: [{GROUP_ORDER_INT}, {Gx}, {Gx_bytes}, .., {sig_hash_preimage}, ..,
+        #               Gx_bytes, 0x0220||Gx_bytes||02, s]
+        # stack out: [{GROUP_ORDER_INT}, {Gx}, {Gx_bytes}, .., {sig_hash_preimage}, ..,
+        #               Gx_bytes, Der(Gx,s)]
+        out += Script.parse_string(
+            "OP_SIZE OP_TUCK OP_TOALTSTACK OP_CAT OP_CAT"
+        )  # Construct 0x0220||Gx||02||len(s)||s and put len(s) on the altstack
+        out += Script.parse_string("0x30 OP_FROMALTSTACK")
+        out += nums_to_script([36])
+        out += Script.parse_string("OP_ADD OP_CAT OP_SWAP OP_CAT")  # Construct DER(Gx,s)
+        out.append_pushdata(sighash_value.to_bytes())
+        out += Script.parse_string("OP_CAT")  # Append SIGHASH_ALL
+
+        # stack in:  [{GROUP_ORDER_INT}, {Gx}, {Gx_bytes}, .., {sig_hash_preimage}, ..,
+        #               Gx_bytes, Der(Gx,s)]
+        # stack out: [{GROUP_ORDER_INT}, {Gx}, {Gx_bytes}, .., {sig_hash_preimage}, ..,
+        #               Der(Gx,s), Gx_bytes]
+        out += Script.parse_string("0x02 OP_ROT OP_CAT")
+
+        if is_checksigverify and not is_opcodeseparator:
+            out += Script.parse_string("OP_CHECKSIGVERIFY")
+        elif is_checksigverify and is_opcodeseparator:
+            out += Script.parse_string("OP_CODESEPARATOR OP_CHECKSIGVERIFY")
+        elif not is_checksigverify and is_opcodeseparator:
+            out += Script.parse_string("OP_CODESEPARATOR OP_CHECKSIG")
+        else:
+            out += Script.parse_string("OP_CHECKSIG")
+
+        return out
+
+    @staticmethod
+    def pushtx_bit_shift(
+        sighash_value: SIGHASH,
+        sig_hash_preimage: StackBaseElement = StackBaseElement(0),  # noqa: B008
+        rolling_option: int = 1,
+        is_checksigverify: bool = True,
+        is_opcodeseparator: bool = False,
+        security: int = 2,
+    ) -> Script:
+        """Construct PUSHTX (with bit shift) locking script.
+
+        Stack input:
+            - stack:    [.. sig_hash_preimage ..]
+            - altstack: []
+        Stack output:
+            - stack:    [.. {sig_hash_preimage} ..] or fail
+            - altstack: []
+
+        Args:
+            sighash_value (SIGHASH): Sighash flag with which the message should be constructed
+            sig_hash_preimage (StackBaseElement): Position in the stack of the sig_hash_preimage.
+                Defaults to StackBaseElement(0) (on top of the stack).
+            rolling_option (int): Whether to roll or pick sig_hash_preimage. Defaults to `1` (roll).
+            is_checksigverify (bool): Whether to execute OP_CHECKSIGVERIFY or OP_CHECKSIG. Defaults
+                to `True` (OP_CHECKSIGVERIFY).
+            is_opcodeseparator (bool): Whether to prepend the signature verification with an
+                OP_CODESEPARATOR (so that the code of pushtx is not signed). Defaults to `False`.
+            security (int): Which integer used to construct the script (2 or 3). Defaults to 2.
+
+        Returns:
+            The Bitcoin Script of PUSHTX with bit shift, which fails unless:
+                - sig_hash_preimage is the message digest of the transaction in which the script is executed.
+                    The message digest of a transactionis defined here:
+                    https://github.com/bitcoin-sv/bitcoin-sv/blob/master/doc/abc/replay-protected-sighash.md#digest-algorithm
+                - sig_hash_preimage % 2**security = 1
+                - sig_hash_preimage >
+                    (0x0100000000000000000000000000000000000000000000000000000000000000 * 2**security + 1)
+
+        """
+
+        assert security in [2, 3], f"Security parameter must be 2 or 3, security: {security}"
+
+        out = Script()
+
+        # stack in:  [.. sig_hash_preimage ..]
+        # stack out: [.. {sig_hash_preimage} .. s]
+        out += move(sig_hash_preimage, bool_to_moving_function(rolling_option))
+        out += (
+            Script.parse_string("OP_HASH256") + nums_to_script([security]) + Script.parse_string("OP_RSHIFT")
+        )  # Compute HASH256(sig_hash_preimage) // 2^security
+
+        # stack out: [.. {sig_hash_preimage} .. s]
+        # stack out: [.. {sig_hash_preimage} .. Der(R,s)]
+        out.append_pushdata(
+            pushtx_bit_shift_data[security]["signature_prefix"]
+            + pushtx_bit_shift_data[security]["R"][1:]
+            + bytes.fromhex("0220")
+        )
+        out += Script.parse_string("OP_SWAP OP_CAT")
+        out.append_pushdata(sighash_value.to_bytes())
+        out += Script.parse_string("OP_CAT")
+
+        # stack in:  [.. {sig_hash_preimage} .. Der(R,s)]
+        # stack out: [.. {sig_hash_preimage} .. Der(R,s) P]
+        out.append_pushdata(pushtx_bit_shift_data[security]["P"])
+
+        if is_checksigverify and not is_opcodeseparator:
+            out += Script.parse_string("OP_CHECKSIGVERIFY")
+        elif is_checksigverify and is_opcodeseparator:
+            out += Script.parse_string("OP_CODESEPARATOR OP_CHECKSIGVERIFY")
+        elif not is_checksigverify and is_opcodeseparator:
+            out += Script.parse_string("OP_CODESEPARATOR OP_CHECKSIG")
+        else:
+            out += Script.parse_string("OP_CHECKSIG")
+
+        return out
+
+    @staticmethod
+    def pushtx_unlock(
+        tx: Tx, index: int, script_pubkey: Script, prev_amount: int, sighash_value: SIGHASH, append_constants: bool
+    ) -> Script:
+        """Construct unlocking script for pushtx.
+
+        Args:
+            tx (Tx): The transaction for which we want to construct the unlocking script.
+            index (int): The index of the UTXO for which we want to construct the unlocking script.
+            script_pubkey (Script): The script_pubkey of the outpoint we want to construct the unlocking
+                script for.
+            prev_amount (int): The amount of the outpoint we want to construct the unlocking
+                script for.
+            sighash_value (SIGHASH): The sighash flag with which the pushtx locking script was constructed.
+            append_constants (bool): Whether or not to append the required constants at the beginning of the script.
+
+        """
+
+        sig_hash_preimage = tx_to_sig_hash_preimage(
+            tx,
+            index,
+            script_pubkey,
+            prev_amount,
+            sighash_value,
+        )
+
+        out = Script()
+        if append_constants:
+            out += nums_to_script([GROUP_ORDER_INT, Gx])
+            out.append_pushdata(Gx_bytes)
+        out.append_pushdata(sig_hash_preimage)
+
+        return out
+
+    @staticmethod
+    def pushtx_bit_shift_unlock(
+        tx: Tx, index: int, script_pubkey: Script, prev_amount: int, sighash_value: SIGHASH, security: int
+    ) -> Union[Tx, Script]:
+        """Construct PUSHTX bit shift unlocking script, it assumes that we can tweak the nSequence of the input.
+
+        Args:
+            tx (Tx): The transaction for which we want to construct the unlocking script.
+            index (int): The index of the UTXO for which we want to construct the unlocking script.
+            script_pubkey (Script): The script_pubkey of the outpoint we want to construct the unlocking
+                script for.
+            prev_amount (int): The amount of the outpoint we want to construct the unlocking
+                script for.
+            sighash_value (SIGHASH): The sighash flag with which the pushtx locking script was constructed.
+            security (int): The security value with which the pushtx_bit_shift locking script was constructed.
+
+        """
+
+        assert security in [2, 3], f"Security parameter must be 2 or 3, security: {security}"
+
+        tx_in = tx.tx_ins[0]
+        sig_hash_preimage = tx_to_sig_hash_preimage(
+            tx,
+            index,
+            script_pubkey,
+            prev_amount,
+            sighash_value,
+        )
+        sig_hash = hash256d(sig_hash_preimage)
+        sig_hash_int = int.from_bytes(sig_hash)
+
+        while sig_hash_int % 2**security != 1 or sig_hash_int <= (
+            0x0100000000000000000000000000000000000000000000000000000000000000 * 2**security + 1
+        ):
+            tx_in.sequence += 1
+            tx_in.sequence = tx_in.sequence % 0xFFFFFFFF
+            tx.tx_ins = [tx_in]
+            sig_hash_preimage = tx_to_sig_hash_preimage(
+                tx,
+                index,
+                script_pubkey,
+                prev_amount,
+                sighash_value,
+            )
+            sig_hash = hash256d(sig_hash_preimage)
+            sig_hash_int = int.from_bytes(sig_hash)
+
+        out = Script()
+        out.append_pushdata(sig_hash_preimage)
+
+        return tx, out

--- a/src/zkscript/transaction_introspection/transaction_introspection.py
+++ b/src/zkscript/transaction_introspection/transaction_introspection.py
@@ -286,8 +286,7 @@ class TransactionIntrospection:
         sig_hash_int = int.from_bytes(sig_hash)
 
         while sig_hash_int % 2**security != 1 or sig_hash_int // 2**security < 2 ** (31 * 8):
-            tx_in.sequence += 1
-            tx_in.sequence = tx_in.sequence % 0xFFFFFFFF
+            tx_in.sequence = (tx_in.sequence + 1) % 0xFFFFFFFF
             tx.tx_ins = [tx_in]
             sig_hash_preimage = tx_to_sig_hash_preimage(
                 tx,

--- a/src/zkscript/transaction_introspection/transaction_introspection.py
+++ b/src/zkscript/transaction_introspection/transaction_introspection.py
@@ -1,22 +1,34 @@
 from typing import Union
 
-from tx_engine import SIGHASH, Script, Tx, hash256d
+from tx_engine import SIGHASH, Script, Tx, encode_num, hash256d
 from tx_engine import sig_hash_preimage as tx_to_sig_hash_preimage
 from tx_engine.engine.util import GROUP_ORDER_INT, Gx, Gx_bytes
 
 from src.zkscript.types.stack_elements import StackBaseElement
-from src.zkscript.util.utility_functions import bool_to_moving_function
-from src.zkscript.util.utility_scripts import ensure_is_positive, move, nums_to_script, pick, reverse_endianness, roll
+from src.zkscript.util.utility_scripts import (
+    bool_to_moving_function,
+    bytes_to_unsigned,
+    int_sig_to_s_component,
+    move,
+    nums_to_script,
+    pick,
+    reverse_endianness,
+    roll,
+)
 
 pushtx_bit_shift_data = {
     2: {
         "signature_prefix": bytes.fromhex("3045022100"),
+        # R = 2^2 * G
         "R": bytes.fromhex("02e493dbf1c10d80f3581e4904930b1404cc6c13900ee0758474fa94abe8c4cd13"),
+        # P = a * G s.t. a * R_x = -1 mod GROUP_ORDER_INT
         "P": bytes.fromhex("034218426b38c75b706db9010aad7795fd05b872060921c048d9a679d8878c7660"),
     },
     3: {
         "signature_prefix": bytes.fromhex("30440220"),
+        # R = 2^2 * G
         "R": bytes.fromhex("022f01e5e15cca351daff3843fb70f3c2f0a1bdd05e5af888a67784ef3e10a2a01"),
+        # P = a * G s.t. a * R_x = -1 mod GROUP_ORDER_INT
         "P": bytes.fromhex("03ad36fad55727ebf76f8af96c7c2df9a298dc21d6c15269fdedfd47a70b327637"),
     },
 }
@@ -27,7 +39,7 @@ class TransactionIntrospection:
     def pushtx(
         sighash_value: SIGHASH,
         sig_hash_preimage: StackBaseElement = StackBaseElement(0),  # noqa: B008
-        rolling_option: int = 1,
+        rolling_option: bool = True,
         clean_constants: bool = True,
         verify_constants: bool = True,
         is_checksigverify: bool = True,
@@ -39,14 +51,14 @@ class TransactionIntrospection:
             - stack:    [GROUP_ORDER_INT, Gx, Gx_bytes, .., sig_hash_preimage, ..]
             - altstack: []
         Stack output:
-            - stack:    [{GROUP_ORDER_INT}, {Gx}, {Gx_bytes}, .., {sig_hash_preimage}, ..] or fail
+            - stack:    [GROUP_ORDER_INT, Gx, Gx_bytes, .., sig_hash_preimage, ..] or fail
             - altstack: []
 
         Args:
             sighash_value (SIGHASH): Sighash flag with which the message should be constructed
             sig_hash_preimage (StackBaseElement): Position in the stack of the sig_hash_preimage.
                 Defaults to StackBaseElement(0) (on top of the stack).
-            rolling_option (int): Whether to roll or pick sig_hash_preimage. Defaults to `1` (roll).
+            rolling_option (int): Whether to roll or pick sig_hash_preimage. Defaults to `True` (roll).
             clean_constants (bool): Whether to clean the constants needed for the script:
                 GROUP_ORDER_INT, Gx, Gx_bytes. Defaults to `True`.
             verify_constants (bool): Whether or not to verify the constants used for the script.
@@ -57,7 +69,7 @@ class TransactionIntrospection:
 
         Returns:
             The Bitcoin Script of PUSHTX, which fails unless sig_hash_preimage is the message digest of the
-            transaction in which the script is executed. The message digest of a transactionis defined here:
+            transaction in which the script is executed. The message digest of a transaction is defined here:
             https://github.com/bitcoin-sv/bitcoin-sv/blob/master/doc/abc/replay-protected-sighash.md#digest-algorithm
 
         """
@@ -65,32 +77,29 @@ class TransactionIntrospection:
         out = Script()
 
         if verify_constants:
-            out += nums_to_script([GROUP_ORDER_INT, Gx])
-            out.append_pushdata(Gx_bytes)
+            out.append_pushdata(hash256d(Gx_bytes + encode_num(Gx) + encode_num(GROUP_ORDER_INT)))
             for i in range(3, 0, -1):
                 out += pick(position=-i, n_elements=1)
-                out += Script.parse_string("OP_EQUALVERIFY")
+            out += Script.parse_string("OP_CAT OP_CAT OP_HASH256 OP_EQUALVERIFY")
 
         # stack in:  [GROUP_ORDER_INT, Gx, Gx_bytes, .., sig_hash_preimage, ..]
-        # stack out: [GROUP_ORDER_INT, Gx, {Gx_bytes}, .., sig_hash_preimage, ..,
+        # stack out: [GROUP_ORDER_INT, Gx, Gx_bytes, .., sig_hash_preimage, ..,
         #               Gx_bytes, 0x0220||Gx_bytes||02]
         out.append_pushdata(bytes.fromhex("0220"))
-        out += (
-            roll(position=-3, n_elements=1) if clean_constants else pick(position=-3, n_elements=1)
-        )  # Move 0x0220||Gx_bytes||02
+        out += roll(position=-3, n_elements=1) if clean_constants else pick(position=-3, n_elements=1)  # Move Gx_bytes
         out += Script.parse_string("OP_TUCK 0x02 OP_CAT OP_CAT")
 
-        # stack in:  [GROUP_ORDER_INT, Gx, {Gx_bytes}, .., sig_hash_preimage, ..,
+        # stack in:  [GROUP_ORDER_INT, Gx, Gx_bytes, .., sig_hash_preimage, ..,
         #               Gx_bytes, 0x0220||Gx_bytes||02]
-        # stack out: [GROUP_ORDER_INT, Gx, {Gx_bytes}, .., {sig_hash_preimage}, ..,
+        # stack out: [GROUP_ORDER_INT, Gx, Gx_bytes, .., sig_hash_preimage, ..,
         #               Gx_bytes, 0x0220||Gx_bytes||02, h]
         out += move(sig_hash_preimage.shift(2), bool_to_moving_function(rolling_option))
-        out += Script.parse_string("OP_HASH256") + reverse_endianness(32) + ensure_is_positive()
+        out += Script.parse_string("OP_HASH256") + reverse_endianness(32) + bytes_to_unsigned()
 
         # Compute the s part of the signature
-        # stack in:  [GROUP_ORDER_INT, Gx, {Gx_bytes}, .., {sig_hash_preimage}, ..,
+        # stack in:  [GROUP_ORDER_INT, Gx, Gx_bytes, .., sig_hash_preimage, ..,
         #               Gx_bytes, 0x0220||Gx_bytes||02, h]
-        # stack out: [{GROUP_ORDER_INT}, {Gx}, {Gx_bytes}, .., {sig_hash_preimage}, ..,
+        # stack out: [GROUP_ORDER_INT, Gx, Gx_bytes, .., sig_hash_preimage, ..,
         #               Gx_bytes, 0x0220||Gx_bytes||02, GROUP_ORDER_INT, (h + Gx) % GROUP_ORDER_INT]
         out += roll(position=-2, n_elements=1) if clean_constants else pick(position=-2, n_elements=1)  # Move Gx
         out += Script.parse_string("OP_ADD")
@@ -99,25 +108,15 @@ class TransactionIntrospection:
         )  # Move GROUP_ORDER_INT
         out += Script.parse_string("OP_TUCK OP_MOD")
 
-        # stack in:  [{GROUP_ORDER_INT}, {Gx}, {Gx_bytes}, .., {sig_hash_preimage}, ..,
+        # stack in:  [GROUP_ORDER_INT, Gx, Gx_bytes, .., sig_hash_preimage, ..,
         #               Gx_bytes, 0x0220||Gx_bytes||02 GROUP_ORDER_INT, (h + Gx) % GROUP_ORDER_INT]
-        # stack out: [{GROUP_ORDER_INT}, {Gx}, {Gx_bytes}, .., {sig_hash_preimage}, ..,
-        #               Gx_bytes, 0x0220||Gx_bytes||02, LittleEndian(s)]
-        out += Script.parse_string(
-            "OP_DUP OP_ROT OP_TUCK OP_2 OP_DIV OP_GREATERTHAN OP_IF OP_SWAP OP_SUB OP_ELSE OP_DROP OP_ENDIF"
-        )
-
-        # stack in:  [{GROUP_ORDER_INT}, {Gx}, {Gx_bytes}, .., {sig_hash_preimage}, ..,
-        #               Gx_bytes, 0x0220||Gx_bytes||02, LittleEndian(s)]
-        # stack out: [{GROUP_ORDER_INT}, {Gx}, {Gx_bytes}, .., {sig_hash_preimage}, ..,
+        # stack out: [GROUP_ORDER_INT, Gx, Gx_bytes, .., sig_hash_preimage, ..,
         #               Gx_bytes, 0x0220||Gx_bytes||02, s]
-        out += Script.parse_string("OP_SIZE OP_SWAP 32 OP_NUM2BIN")
-        out += reverse_endianness(32)
-        out += Script.parse_string("0x20 OP_ROT OP_SUB OP_SPLIT OP_NIP")
+        out += int_sig_to_s_component(add_prefix=False)
 
-        # stack in: [{GROUP_ORDER_INT}, {Gx}, {Gx_bytes}, .., {sig_hash_preimage}, ..,
+        # stack in: [GROUP_ORDER_INT, Gx, Gx_bytes, .., sig_hash_preimage, ..,
         #               Gx_bytes, 0x0220||Gx_bytes||02, s]
-        # stack out: [{GROUP_ORDER_INT}, {Gx}, {Gx_bytes}, .., {sig_hash_preimage}, ..,
+        # stack out: [GROUP_ORDER_INT, Gx, Gx_bytes, .., sig_hash_preimage, ..,
         #               Gx_bytes, Der(Gx,s)]
         out += Script.parse_string(
             "OP_SIZE OP_TUCK OP_TOALTSTACK OP_CAT OP_CAT"
@@ -126,11 +125,11 @@ class TransactionIntrospection:
         out += nums_to_script([36])
         out += Script.parse_string("OP_ADD OP_CAT OP_SWAP OP_CAT")  # Construct DER(Gx,s)
         out.append_pushdata(sighash_value.to_bytes())
-        out += Script.parse_string("OP_CAT")  # Append SIGHASH_ALL
+        out += Script.parse_string("OP_CAT")  # Append SIGHASH
 
-        # stack in:  [{GROUP_ORDER_INT}, {Gx}, {Gx_bytes}, .., {sig_hash_preimage}, ..,
+        # stack in:  [GROUP_ORDER_INT, Gx, Gx_bytes, .., sig_hash_preimage, ..,
         #               Gx_bytes, Der(Gx,s)]
-        # stack out: [{GROUP_ORDER_INT}, {Gx}, {Gx_bytes}, .., {sig_hash_preimage}, ..,
+        # stack out: [GROUP_ORDER_INT, Gx, Gx_bytes, .., sig_hash_preimage, ..,
         #               Der(Gx,s), Gx_bytes]
         out += Script.parse_string("0x02 OP_ROT OP_CAT")
 
@@ -149,7 +148,7 @@ class TransactionIntrospection:
     def pushtx_bit_shift(
         sighash_value: SIGHASH,
         sig_hash_preimage: StackBaseElement = StackBaseElement(0),  # noqa: B008
-        rolling_option: int = 1,
+        rolling_option: bool = True,
         is_checksigverify: bool = True,
         is_opcodeseparator: bool = False,
         security: int = 2,
@@ -160,14 +159,14 @@ class TransactionIntrospection:
             - stack:    [.. sig_hash_preimage ..]
             - altstack: []
         Stack output:
-            - stack:    [.. {sig_hash_preimage} ..] or fail
+            - stack:    [.. sig_hash_preimage ..] or fail
             - altstack: []
 
         Args:
             sighash_value (SIGHASH): Sighash flag with which the message should be constructed
             sig_hash_preimage (StackBaseElement): Position in the stack of the sig_hash_preimage.
                 Defaults to StackBaseElement(0) (on top of the stack).
-            rolling_option (int): Whether to roll or pick sig_hash_preimage. Defaults to `1` (roll).
+            rolling_option (int): Whether to roll or pick sig_hash_preimage. Defaults to `True` (roll).
             is_checksigverify (bool): Whether to execute OP_CHECKSIGVERIFY or OP_CHECKSIG. Defaults
                 to `True` (OP_CHECKSIGVERIFY).
             is_opcodeseparator (bool): Whether to prepend the signature verification with an
@@ -180,8 +179,7 @@ class TransactionIntrospection:
                     The message digest of a transactionis defined here:
                     https://github.com/bitcoin-sv/bitcoin-sv/blob/master/doc/abc/replay-protected-sighash.md#digest-algorithm
                 - sig_hash_preimage % 2**security = 1
-                - sig_hash_preimage >
-                    (0x0100000000000000000000000000000000000000000000000000000000000000 * 2**security + 1)
+                - sig_hash_preimage // 2**security >= 2**(31*8)
 
         """
 
@@ -190,14 +188,14 @@ class TransactionIntrospection:
         out = Script()
 
         # stack in:  [.. sig_hash_preimage ..]
-        # stack out: [.. {sig_hash_preimage} .. s]
+        # stack out: [.. sig_hash_preimage .. s]
         out += move(sig_hash_preimage, bool_to_moving_function(rolling_option))
         out += (
             Script.parse_string("OP_HASH256") + nums_to_script([security]) + Script.parse_string("OP_RSHIFT")
         )  # Compute HASH256(sig_hash_preimage) // 2^security
 
-        # stack out: [.. {sig_hash_preimage} .. s]
-        # stack out: [.. {sig_hash_preimage} .. Der(R,s)]
+        # stack out: [.. sig_hash_preimage .. s]
+        # stack out: [.. sig_hash_preimage .. Der(R,s)]
         out.append_pushdata(
             pushtx_bit_shift_data[security]["signature_prefix"]
             + pushtx_bit_shift_data[security]["R"][1:]
@@ -207,8 +205,8 @@ class TransactionIntrospection:
         out.append_pushdata(sighash_value.to_bytes())
         out += Script.parse_string("OP_CAT")
 
-        # stack in:  [.. {sig_hash_preimage} .. Der(R,s)]
-        # stack out: [.. {sig_hash_preimage} .. Der(R,s) P]
+        # stack in:  [.. sig_hash_preimage .. Der(R,s)]
+        # stack out: [.. sig_hash_preimage .. Der(R,s) P]
         out.append_pushdata(pushtx_bit_shift_data[security]["P"])
 
         if is_checksigverify and not is_opcodeseparator:
@@ -287,9 +285,7 @@ class TransactionIntrospection:
         sig_hash = hash256d(sig_hash_preimage)
         sig_hash_int = int.from_bytes(sig_hash)
 
-        while sig_hash_int % 2**security != 1 or sig_hash_int <= (
-            0x0100000000000000000000000000000000000000000000000000000000000000 * 2**security + 1
-        ):
+        while sig_hash_int % 2**security != 1 or sig_hash_int // 2**security < 2 ** (31 * 8):
             tx_in.sequence += 1
             tx_in.sequence = tx_in.sequence % 0xFFFFFFFF
             tx.tx_ins = [tx_in]

--- a/src/zkscript/transaction_introspection/transaction_introspection.py
+++ b/src/zkscript/transaction_introspection/transaction_introspection.py
@@ -87,7 +87,7 @@ class TransactionIntrospection:
         #               Gx_bytes, 0x0220||Gx_bytes||02]
         out.append_pushdata(bytes.fromhex("0220"))
         out += roll(position=-3, n_elements=1) if clean_constants else pick(position=-3, n_elements=1)  # Move Gx_bytes
-        out += Script.parse_string("OP_TUCK 0x02 OP_CAT OP_CAT")
+        out += Script.parse_string("OP_TUCK OP_2 OP_CAT OP_CAT")
 
         # stack in:  [GROUP_ORDER_INT, Gx, Gx_bytes, .., sig_hash_preimage, ..,
         #               Gx_bytes, 0x0220||Gx_bytes||02]
@@ -131,7 +131,7 @@ class TransactionIntrospection:
         #               Gx_bytes, Der(Gx,s)]
         # stack out: [GROUP_ORDER_INT, Gx, Gx_bytes, .., sig_hash_preimage, ..,
         #               Der(Gx,s), Gx_bytes]
-        out += Script.parse_string("0x02 OP_ROT OP_CAT")
+        out += Script.parse_string("OP_2 OP_ROT OP_CAT")
 
         if is_checksigverify and not is_opcodeseparator:
             out += Script.parse_string("OP_CHECKSIGVERIFY")

--- a/src/zkscript/transaction_introspection/transaction_introspection.py
+++ b/src/zkscript/transaction_introspection/transaction_introspection.py
@@ -11,7 +11,6 @@ from src.zkscript.util.utility_scripts import (
     move,
     nums_to_script,
     pick,
-    reverse_endianness,
     roll,
 )
 
@@ -52,7 +51,8 @@ class TransactionIntrospection:
             - stack:    [GROUP_ORDER_INT, Gx, Gx_bytes, .., sig_hash_preimage, ..]
             - altstack: []
         Stack output:
-            - stack:    [GROUP_ORDER_INT, Gx, Gx_bytes, .., sig_hash_preimage, ..] or fail
+            - stack:    [GROUP_ORDER_INT, Gx, Gx_bytes, .., sig_hash_preimage, ..] or fail (
+                `clean_constants = False`, `rolling_option = False`, `is_checksigverify = True`)
             - altstack: []
 
         Args:
@@ -60,8 +60,8 @@ class TransactionIntrospection:
             sig_hash_preimage (StackBaseElement): Position in the stack of the sig_hash_preimage.
                 Defaults to StackBaseElement(0) (on top of the stack).
             rolling_option (int): Whether to roll or pick sig_hash_preimage. Defaults to `True` (roll).
-            clean_constants (bool): Whether to clean the constants needed for the script:
-                GROUP_ORDER_INT, Gx, Gx_bytes. Defaults to `True`.
+            clean_constants (bool): If `True`, the costants GROUP_ORDER_INT, Gx, Gx_bytes are removed
+                from the stack after execution. Defaults to `True`.
             verify_constants (bool): Whether or not to verify the constants used for the script.
             is_checksigverify (bool): Whether to execute OP_CHECKSIGVERIFY or OP_CHECKSIG. Defaults
                 to `True` (OP_CHECKSIGVERIFY).
@@ -69,7 +69,10 @@ class TransactionIntrospection:
                 OP_CODESEPARATOR (so that the code of pushtx is not signed). Defaults to `False`.
 
         Returns:
-            The Bitcoin Script of PUSHTX, which fails unless sig_hash_preimage is the message digest of the
+            The Bitcoin Script of PUSHTX.
+
+        Note:
+            The script fails unless sig_hash_preimage is the message digest of the
             transaction in which the script is executed. The message digest of a transaction is defined here:
             https://github.com/bitcoin-sv/bitcoin-sv/blob/master/doc/abc/replay-protected-sighash.md#digest-algorithm
         """
@@ -90,16 +93,12 @@ class TransactionIntrospection:
         out += roll(position=-3, n_elements=1) if clean_constants else pick(position=-3, n_elements=1)  # Move Gx_bytes
         out += Script.parse_string("OP_TUCK OP_2 OP_CAT OP_CAT")
 
-        # stack in:  [GROUP_ORDER_INT, Gx, Gx_bytes, .., sig_hash_preimage, ..,
-        #               Gx_bytes, 0x0220||Gx_bytes||02]
         # stack out: [GROUP_ORDER_INT, Gx, Gx_bytes, .., sig_hash_preimage, ..,
         #               Gx_bytes, 0x0220||Gx_bytes||02, h]
         out += move(sig_hash_preimage.shift(2), bool_to_moving_function(rolling_option))
-        out += Script.parse_string("OP_HASH256") + reverse_endianness(32) + bytes_to_unsigned()
+        out += Script.parse_string("OP_HASH256") + bytes_to_unsigned(32)
 
         # Compute the s part of the signature
-        # stack in:  [GROUP_ORDER_INT, Gx, Gx_bytes, .., sig_hash_preimage, ..,
-        #               Gx_bytes, 0x0220||Gx_bytes||02, h]
         # stack out: [GROUP_ORDER_INT, Gx, Gx_bytes, .., sig_hash_preimage, ..,
         #               Gx_bytes, 0x0220||Gx_bytes||02, GROUP_ORDER_INT, (h + Gx) % GROUP_ORDER_INT]
         out += roll(position=-2, n_elements=1) if clean_constants else pick(position=-2, n_elements=1)  # Move Gx
@@ -109,14 +108,10 @@ class TransactionIntrospection:
         )  # Move GROUP_ORDER_INT
         out += Script.parse_string("OP_TUCK OP_MOD")
 
-        # stack in:  [GROUP_ORDER_INT, Gx, Gx_bytes, .., sig_hash_preimage, ..,
-        #               Gx_bytes, 0x0220||Gx_bytes||02 GROUP_ORDER_INT, (h + Gx) % GROUP_ORDER_INT]
         # stack out: [GROUP_ORDER_INT, Gx, Gx_bytes, .., sig_hash_preimage, ..,
         #               Gx_bytes, 0x0220||Gx_bytes||02, s]
         out += int_sig_to_s_component(add_prefix=False)
 
-        # stack in: [GROUP_ORDER_INT, Gx, Gx_bytes, .., sig_hash_preimage, ..,
-        #               Gx_bytes, 0x0220||Gx_bytes||02, s]
         # stack out: [GROUP_ORDER_INT, Gx, Gx_bytes, .., sig_hash_preimage, ..,
         #               Gx_bytes, Der(Gx,s)]
         out += Script.parse_string(
@@ -128,20 +123,12 @@ class TransactionIntrospection:
         out.append_pushdata(sighash_value.to_bytes())
         out += Script.parse_string("OP_CAT")  # Append SIGHASH
 
-        # stack in:  [GROUP_ORDER_INT, Gx, Gx_bytes, .., sig_hash_preimage, ..,
-        #               Gx_bytes, Der(Gx,s)]
         # stack out: [GROUP_ORDER_INT, Gx, Gx_bytes, .., sig_hash_preimage, ..,
         #               Der(Gx,s), Gx_bytes]
         out += Script.parse_string("OP_2 OP_ROT OP_CAT")
 
-        if is_checksigverify and not is_opcodeseparator:
-            out += Script.parse_string("OP_CHECKSIGVERIFY")
-        elif is_checksigverify and is_opcodeseparator:
-            out += Script.parse_string("OP_CODESEPARATOR OP_CHECKSIGVERIFY")
-        elif not is_checksigverify and is_opcodeseparator:
-            out += Script.parse_string("OP_CODESEPARATOR OP_CHECKSIG")
-        else:
-            out += Script.parse_string("OP_CHECKSIG")
+        out += Script.parse_string("OP_CODESEPARATOR" if is_opcodeseparator else "")
+        out += Script.parse_string("OP_CHECKSIGVERIFY" if is_checksigverify else "OP_CHECKSIG")
 
         return out
 
@@ -171,13 +158,16 @@ class TransactionIntrospection:
             is_checksigverify (bool): Whether to execute OP_CHECKSIGVERIFY or OP_CHECKSIG. Defaults
                 to `True` (OP_CHECKSIGVERIFY).
             is_opcodeseparator (bool): Whether to prepend the signature verification with an
-                OP_CODESEPARATOR (so that the code of pushtx is not signed). Defaults to `False`.
+                OP_CODESEPARATOR (so that the code of PUSHTX is not signed). Defaults to `False`.
             security (int): Which integer used to construct the script (2 or 3). Defaults to 2.
 
         Returns:
-            The Bitcoin Script of PUSHTX with bit shift, which fails unless:
+            The Bitcoin Script of PUSHTX with bit shift.
+
+        Note:
+            The script fails unless:
                 - sig_hash_preimage is the message digest of the transaction in which the script is executed.
-                    The message digest of a transactionis defined here:
+                    The message digest of a transaction is defined here:
                     https://github.com/bitcoin-sv/bitcoin-sv/blob/master/doc/abc/replay-protected-sighash.md#digest-algorithm
                 - sig_hash_preimage % 2**security = 1
                 - sig_hash_preimage // 2**security >= 2**(31*8)
@@ -193,7 +183,6 @@ class TransactionIntrospection:
             Script.parse_string("OP_HASH256") + nums_to_script([security]) + Script.parse_string("OP_RSHIFT")
         )  # Compute HASH256(sig_hash_preimage) // 2^security
 
-        # stack out: [.. sig_hash_preimage .. s]
         # stack out: [.. sig_hash_preimage .. Der(R,s)]
         out.append_pushdata(
             pushtx_bit_shift_data[security]["signature_prefix"]
@@ -204,17 +193,10 @@ class TransactionIntrospection:
         out.append_pushdata(sighash_value.to_bytes())
         out += Script.parse_string("OP_CAT")
 
-        # stack in:  [.. sig_hash_preimage .. Der(R,s)]
         # stack out: [.. sig_hash_preimage .. Der(R,s) P]
         out.append_pushdata(pushtx_bit_shift_data[security]["P"])
 
-        if is_checksigverify and not is_opcodeseparator:
-            out += Script.parse_string("OP_CHECKSIGVERIFY")
-        elif is_checksigverify and is_opcodeseparator:
-            out += Script.parse_string("OP_CODESEPARATOR OP_CHECKSIGVERIFY")
-        elif not is_checksigverify and is_opcodeseparator:
-            out += Script.parse_string("OP_CODESEPARATOR OP_CHECKSIG")
-        else:
-            out += Script.parse_string("OP_CHECKSIG")
+        out += Script.parse_string("OP_CODESEPARATOR" if is_opcodeseparator else "")
+        out += Script.parse_string("OP_CHECKSIGVERIFY" if is_checksigverify else "OP_CHECKSIG")
 
         return out

--- a/src/zkscript/transaction_introspection/transaction_introspection.py
+++ b/src/zkscript/transaction_introspection/transaction_introspection.py
@@ -77,9 +77,11 @@ class TransactionIntrospection:
         out = Script()
 
         if verify_constants:
-            out.append_pushdata(hash256d(Gx_bytes + encode_num(Gx) + encode_num(GROUP_ORDER_INT)))
+            out.append_pushdata(
+                hash256d(hash256d(Gx_bytes) + hash256d(encode_num(Gx)) + hash256d(encode_num(GROUP_ORDER_INT)))
+            )
             for i in range(3, 0, -1):
-                out += pick(position=-i, n_elements=1)
+                out += pick(position=-i, n_elements=1) + Script.parse_string("OP_HASH256")
             out += Script.parse_string("OP_CAT OP_CAT OP_HASH256 OP_EQUALVERIFY")
 
         # stack in:  [GROUP_ORDER_INT, Gx, Gx_bytes, .., sig_hash_preimage, ..]

--- a/src/zkscript/transaction_introspection/transaction_introspection.py
+++ b/src/zkscript/transaction_introspection/transaction_introspection.py
@@ -26,7 +26,7 @@ pushtx_bit_shift_data = {
     },
     3: {
         "signature_prefix": bytes.fromhex("30440220"),
-        # R = 2^2 * G
+        # R = 2^3 * G
         "R": bytes.fromhex("022f01e5e15cca351daff3843fb70f3c2f0a1bdd05e5af888a67784ef3e10a2a01"),
         # P = a * G s.t. a * R_x = -1 mod GROUP_ORDER_INT
         "P": bytes.fromhex("03ad36fad55727ebf76f8af96c7c2df9a298dc21d6c15269fdedfd47a70b327637"),

--- a/src/zkscript/types/unlocking_keys/__init__.py
+++ b/src/zkscript/types/unlocking_keys/__init__.py
@@ -6,4 +6,5 @@ Modules:
     - miller_loops- implement classes MillerLoopUnlockingKey and TripleMillerLoopUnlockingKey.
     - pairings - implement classes SinglePairingUnlockingKey and TriplePairingUnlockingKey.
     - unrolled_ec_multiplication - implement class EllipticCurveFqUnrolledUnlockingKey.
+    - transaction_introspection - implement classes PushTxUnlockingKey and PushTxBitShiftUnlockingKey.
 """

--- a/src/zkscript/types/unlocking_keys/transaction_introspection.py
+++ b/src/zkscript/types/unlocking_keys/transaction_introspection.py
@@ -1,0 +1,109 @@
+"""Unlocking keys for transaction introspection."""
+
+from dataclasses import dataclass
+from typing import Union
+
+from tx_engine import SIGHASH, Script, Tx, hash256d
+from tx_engine import sig_hash_preimage as tx_to_sig_hash_preimage
+from tx_engine.engine.util import GROUP_ORDER_INT, Gx, Gx_bytes
+
+from src.zkscript.util.utility_scripts import nums_to_script
+
+
+@dataclass
+class PushTxUnlockingKey:
+    """Class encapsulating the data required for unlocking PUSHTX.
+
+    Attributes:
+        tx (Tx): The transaction for which we want to construct the unlocking script.
+        index (int): The index of the UTXO for which we want to construct the unlocking script.
+        script_pubkey (Script): The script_pubkey of the outpoint we want to construct the unlocking
+            script for.
+        prev_amount (int): The amount of the outpoint we want to construct the unlocking
+            script for.
+    """
+
+    tx: Tx
+    index: int
+    script_pubkey: Script
+    prev_amount: int
+
+    def to_unlocking_script(self, sighash_value: SIGHASH, append_constants: bool) -> Script:
+        """Construct unlocking script for the `pushtx` method.
+
+        Args:
+            sighash_value (SIGHASH): The sighash flag with which the PUSHTX locking script was constructed.
+            append_constants (bool): Whether or not to append the required constants at the beginning of the script.
+        """
+        sig_hash_preimage = tx_to_sig_hash_preimage(
+            self.tx,
+            self.index,
+            self.script_pubkey,
+            self.prev_amount,
+            sighash_value,
+        )
+
+        out = Script()
+        if append_constants:
+            out += nums_to_script([GROUP_ORDER_INT, Gx])
+            out.append_pushdata(Gx_bytes)
+        out.append_pushdata(sig_hash_preimage)
+
+        return out
+
+
+@dataclass
+class PushTxBitShiftUnlockingKey:
+    """Class encapsulating the data required for unlocking PUSHTX_BIT_SHIFT.
+
+    Attributes:
+        tx (Tx): The transaction for which we want to construct the unlocking script.
+        index (int): The index of the UTXO for which we want to construct the unlocking script.
+        script_pubkey (Script): The script_pubkey of the outpoint we want to construct the unlocking
+            script for.
+        prev_amount (int): The amount of the outpoint we want to construct the unlocking
+            script for.
+    """
+
+    tx: Tx
+    index: int
+    script_pubkey: Script
+    prev_amount: int
+
+    def to_unlocking_script(self, sighash_value: SIGHASH, security: int) -> Union[Tx, Script]:
+        """Construct unlocking script for the `pushtx_bit_shift` method.
+
+        Args:
+            sighash_value (SIGHASH): The sighash flag with which the PUSHTX_BIT_SHIFT locking script was constructed.
+            security (int): The security value with which the PUSHTX_BIT_SHIFT locking script was constructed.
+        """
+        assert security in [2, 3], f"Security parameter must be 2 or 3, security: {security}"
+
+        tx_in = self.tx.tx_ins[0]
+        sig_hash_preimage = tx_to_sig_hash_preimage(
+            self.tx,
+            self.index,
+            self.script_pubkey,
+            self.prev_amount,
+            sighash_value,
+        )
+        sig_hash = hash256d(sig_hash_preimage)
+        sig_hash_int = int.from_bytes(sig_hash)
+
+        while sig_hash_int % 2**security != 1 or sig_hash_int // 2**security < 2 ** (31 * 8):
+            tx_in.sequence = (tx_in.sequence + 1) % 0xFFFFFFFF
+            self.tx.tx_ins = [tx_in]
+            sig_hash_preimage = tx_to_sig_hash_preimage(
+                self.tx,
+                self.index,
+                self.script_pubkey,
+                self.prev_amount,
+                sighash_value,
+            )
+            sig_hash = hash256d(sig_hash_preimage)
+            sig_hash_int = int.from_bytes(sig_hash)
+
+        out = Script()
+        out.append_pushdata(sig_hash_preimage)
+
+        return out

--- a/src/zkscript/util/utility_functions.py
+++ b/src/zkscript/util/utility_functions.py
@@ -1,12 +1,10 @@
 """Utility functions."""
 
-from math import ceil, log2
 from typing import Union
 
 from tx_engine import Script
 
 from src.zkscript.types.stack_elements import StackElements
-from src.zkscript.util.utility_scripts import pick, roll
 
 
 def optimise_script(script: Script) -> Script:
@@ -110,11 +108,6 @@ def bitmask_to_boolean_list(bitmask: int, list_length: int) -> list[bool]:
     return [*out, *[False] * (list_length - len(out))]
 
 
-def bool_to_moving_function(is_rolled: bool) -> Union[pick, roll]:
-    """Map is_rolled (bool) to corresponding moving function."""
-    return roll if is_rolled else pick
-
-
 def base_function_size_estimation_miller_loop(
     modulus: int,
     modulo_threshold: int,
@@ -156,28 +149,28 @@ def base_function_size_estimation_miller_loop(
         future_size_miller_output = current_size_miller_output
         future_size_miller_output = 2 * future_size_miller_output + n
         for _ in range(multiplier):
-            future_size_miller_output = ceil(log2(modulus)) + future_size_miller_output + n
-        future_size_point_multiplication = ceil(log2(modulus)) + current_size_point_multiplication + ceil(log2(6))
+            future_size_miller_output = modulus.bit_length() + future_size_miller_output + n
+        future_size_point_multiplication = modulus.bit_length() + current_size_point_multiplication + (6).bit_length()
     else:
         multiplier = 6 if is_triple_miller_loop else 2
         # Next iteration update will be: f <-- f^2 * line_eval * line_eval, T <-- 2T ± Q
         future_size_miller_output = current_size_miller_output
         future_size_miller_output = 2 * future_size_miller_output + n
         for _ in range(multiplier):
-            future_size_miller_output = ceil(log2(modulus)) + future_size_miller_output + n
-        future_size_point_multiplication = ceil(log2(modulus)) + current_size_point_multiplication + ceil(log2(6))
-        future_size_point_multiplication = ceil(log2(modulus)) + future_size_point_multiplication + ceil(log2(6))
+            future_size_miller_output = modulus.bit_length() + future_size_miller_output + n
+        future_size_point_multiplication = modulus.bit_length() + current_size_point_multiplication + (6).bit_length()
+        future_size_point_multiplication = modulus.bit_length() + future_size_point_multiplication + (6).bit_length()
 
     if future_size_miller_output > modulo_threshold:
         take_modulo_miller_loop_output = True
-        out_size_miller_loop = ceil(log2(modulus))
+        out_size_miller_loop = modulus.bit_length()
     else:
         take_modulo_miller_loop_output = False
         out_size_miller_loop = future_size_miller_output
 
     if future_size_point_multiplication > modulo_threshold:
         take_modulo_point_multiplication = True
-        out_size_point_miller_loop = ceil(log2(modulus))
+        out_size_point_miller_loop = modulus.bit_length()
     else:
         take_modulo_point_multiplication = False
         out_size_point_miller_loop = future_size_point_multiplication

--- a/src/zkscript/util/utility_scripts.py
+++ b/src/zkscript/util/utility_scripts.py
@@ -328,3 +328,16 @@ def move(
         msg += f"Self has {length} elements, end_index: {end_index}"
         raise ValueError(msg)
     return moving_function(position=stack_element.position - start_index, n_elements=end_index - start_index)
+
+
+def reverse_endianness(length: int) -> Script:
+    """Reverse the endianness of a bytestring of length `length`."""
+    out = Script()
+    out += Script.parse_string(" ".join(["OP_1 OP_SPLIT"] * (length - 1)))
+    out += Script.parse_string(" ".join(["OP_SWAP OP_CAT"] * (length - 1)))
+    return out
+
+
+def ensure_is_positive() -> Script:
+    """Convert an unsigned integer into a positive integer."""
+    return Script.parse_string("0x00 OP_CAT OP_BIN2NUM")

--- a/src/zkscript/util/utility_scripts.py
+++ b/src/zkscript/util/utility_scripts.py
@@ -45,7 +45,9 @@ from src.zkscript.types.stack_elements import (
     StackElements,
     StackEllipticCurvePoint,
     StackFiniteFieldElement,
+    StackNumber,
 )
+from src.zkscript.util.utility_functions import bitmask_to_boolean_list, check_order
 
 patterns_to_pick = {
     (0, 1): [OP_DUP],
@@ -331,6 +333,11 @@ def move(
     return moving_function(position=stack_element.position - start_index, n_elements=end_index - start_index)
 
 
+def bool_to_moving_function(is_rolled: bool) -> Union[pick, roll]:
+    """Map is_rolled (bool) to corresponding moving function."""
+    return roll if is_rolled else pick
+
+
 def reverse_endianness(
     length: int,
     stack_element: StackBaseElement = StackBaseElement(0),  # noqa: B008
@@ -351,6 +358,103 @@ def reverse_endianness(
     return out
 
 
-def ensure_is_positive() -> Script:
-    """Convert an unsigned integer into a positive integer."""
-    return Script.parse_string("0x00 OP_CAT OP_BIN2NUM")
+def reverse_endianness_unknown_length(
+    max_length: int,
+    stack_element: StackBaseElement = StackBaseElement(0),  # noqa: B008
+    rolling_option: bool = True,
+) -> Script:
+    """Reverse the endianness of a StackBaseElement of byte length at most `max_length`.
+
+    Args:
+        max_length (int): The maximum byte length of stack_element.
+        stack_element (StackBaseElement): The stack element whose endianness should be reversed.
+            Defaults to `StackBaseElement(0)`.
+        rolling_option (bool): Whether stack_element should be rolled. Defaults to `True`.
+
+    """
+    out = move(stack_element, roll if rolling_option else pick)  # Move stack_element
+
+    # stack in: [.., stack_element, .., stack_element]
+    # stack out: [.., stack_element, .., len(stack_element), right_padded(stack_element,max_length)]
+    out += Script.parse_string("OP_SIZE OP_SWAP")
+    out += Script.parse_string("0x00 OP_CAT")
+    out += nums_to_script([max_length + 1])
+    out += Script.parse_string("OP_NUM2BIN")
+
+    # stack in:  [.., stack_element, .., len(stack_element), right_padded(stack_element,max_length)]
+    # stack out: [.., stack_element, .., reverse_endianness(stack_element)
+    out += reverse_endianness(max_length + 1)
+    out += nums_to_script([max_length + 1])
+    out += Script.parse_string(
+        "OP_ROT OP_SUB OP_SPLIT OP_NIP"
+    )  # Reset reverse_endianness(stack_element) to its correct length
+    return out
+
+
+def int_sig_to_s_component(
+    group_order: StackNumber = StackNumber(1, False),  # noqa: B008
+    int_sig: StackNumber = StackNumber(0, False),  # noqa: B008
+    rolling_options: int = 3,
+    add_prefix: bool = True,
+) -> Script:
+    """Return the script that transforms int_sig to the s-component of a secp256k1 ECDSA signature.
+
+    Args:
+        group_order (StackNumber): The position in the stack of the group order of secp256k1. Defaults
+            to `StackNumber(1,False)`.
+        int_sig (StackNumber): The position in the stack of int_sig. Defaults to `StackNumber(0,False)`.
+        rolling_options (int): Whether or not to roll group_order and int_sig, defaults to 3 (roll everything).
+        add_prefix (bool): Whether or not to prepend s with 0x02||len(s). Defaults to `True`.
+    """
+    is_group_order_rolled, is_int_sig_rolled = bitmask_to_boolean_list(rolling_options, 2)
+
+    if [int_sig.position, group_order.position] == [1, 0]:
+        # stack in:  [.., int_sig, group_order]
+        # stack in:  [.., int_sig, group_order, int_sig, group_order] if all([is_group_order_rolled, is_int_sig_rolled])
+        #                else [.., int_sig, group_order, int_sig, group_order, int_sig, group_order]
+        out = Script.parse_string("OP_2DUP" if all([is_group_order_rolled, is_int_sig_rolled]) else "OP_2DUP OP_2DUP")
+    elif [int_sig.position, group_order.position] == [0, 1]:
+        # stack in:  [.., group_order, int_sig]
+        # stack in:  [.., int_sig, group_order, int_sig, group_order] if all([is_group_order_rolled, is_int_sig_rolled])
+        #                else [.., group_order, int_sig, int_sig, group_order, int_sig, group_order]
+        out = Script.parse_string(
+            "OP_SWAP OP_2DUP" if all([is_group_order_rolled, is_int_sig_rolled]) else "OP_2DUP OP_SWAP OP_2DUP"
+        )
+    else:
+        if group_order.position >= 0:
+            check_order([group_order, int_sig])
+        # stack in:  [.., group_order, .., int_sig, ..]
+        # stack out: [.., group_order, .., int_sig, .., int_sig, group_order, int_sig, group_order]
+        out = move(int_sig, bool_to_moving_function(is_int_sig_rolled))  # Move int_sig
+        out += Script.parse_string("OP_DUP")  # Duplicate int_sig
+        out += move(
+            group_order.shift(2 - is_int_sig_rolled if group_order.position >= 0 else 0),
+            bool_to_moving_function(is_group_order_rolled),
+        )  # Move group_order
+        out += Script.parse_string("OP_TUCK")
+
+    # Put int_sig in canonical form
+    # stack in:  [.., group_order, .., int_sig, ..]
+    # stack out: [.., {group_order}, .., {int_sig}, .., min{int_sig, group_order - int_sig}]
+    out += Script.parse_string("OP_2 OP_DIV OP_GREATERTHAN OP_IF OP_SWAP OP_SUB OP_ELSE OP_DROP OP_ENDIF")
+
+    # Reverse endianness of min{int_sig, group_order - int_sig}
+    # stack in:  [.., {group_order}, .., {int_sig}, .., min{int_sig, group_order - int_sig}]
+    # stack out: [.., {group_order}, .., {int_sig}, .., s]
+    out += reverse_endianness_unknown_length(max_length=32)
+
+    if add_prefix:
+        out += Script.parse_string("OP_SIZE OP_SWAP OP_CAT")  # Compute len(s)||s
+        out.append_pushdata(bytes.fromhex("02"))
+        out += Script.parse_string("OP_SWAP OP_CAT")  # Compute 02||len(s)||s
+
+    return out
+
+
+def bytes_to_unsigned(
+    stack_element: StackNumber = StackNumber(0, False),  # noqa: B008
+    rolling_option: bool = True,
+) -> Script:
+    """Convert a bytestring to an unsigned integer."""
+    out = move(stack_element, roll if rolling_option else pick)  # Move stack element
+    return out + Script.parse_string("0x00 OP_CAT OP_BIN2NUM")

--- a/src/zkscript/util/utility_scripts.py
+++ b/src/zkscript/util/utility_scripts.py
@@ -445,8 +445,7 @@ def int_sig_to_s_component(
 
     if add_prefix:
         out += Script.parse_string("OP_SIZE OP_SWAP OP_CAT")  # Compute len(s)||s
-        out.append_pushdata(bytes.fromhex("02"))
-        out += Script.parse_string("OP_SWAP OP_CAT")  # Compute 02||len(s)||s
+        out += Script.parse_string("OP_2 OP_SWAP OP_CAT")  # Compute 02||len(s)||s
 
     return out
 

--- a/src/zkscript/util/utility_scripts.py
+++ b/src/zkscript/util/utility_scripts.py
@@ -451,9 +451,23 @@ def int_sig_to_s_component(
 
 
 def bytes_to_unsigned(
-    stack_element: StackNumber = StackNumber(0, False),  # noqa: B008
+    stack_element: StackBaseElement = StackBaseElement(0),  # noqa: B008
     rolling_option: bool = True,
 ) -> Script:
-    """Convert a bytestring to an unsigned integer."""
+    """Convert a bytestring to an unsigned integer.
+
+    Stack input:
+        - stack: [.., stack_element, ..]
+    Stack output:
+        - stack: [.., stack_element, .., n] where `n` is `stack_element` if the first byte of `stack_element`
+            is less than 0x80, else `stack_element||00`
+
+    Args:
+        stack_element (StackBaseElement): The bytestring to convert into a number
+        rolling_option (bool): If `True`, stack_element is removed from the stack. Defaults to `True`.
+
+    Returns:
+        The script that converts `stack_element` into an unsigned number.
+    """
     out = move(stack_element, roll if rolling_option else pick)  # Move stack element
     return out + Script.parse_string("0x00 OP_CAT OP_BIN2NUM")

--- a/src/zkscript/util/utility_scripts.py
+++ b/src/zkscript/util/utility_scripts.py
@@ -41,6 +41,7 @@ from tx_engine.engine.op_codes import (
 )
 
 from src.zkscript.types.stack_elements import (
+    StackBaseElement,
     StackElements,
     StackEllipticCurvePoint,
     StackFiniteFieldElement,
@@ -330,9 +331,21 @@ def move(
     return moving_function(position=stack_element.position - start_index, n_elements=end_index - start_index)
 
 
-def reverse_endianness(length: int) -> Script:
-    """Reverse the endianness of a bytestring of length `length`."""
-    out = Script()
+def reverse_endianness(
+    length: int,
+    stack_element: StackBaseElement = StackBaseElement(0),  # noqa: B008
+    rolling_option: bool = True,
+) -> Script:
+    """Reverse the endianness of a StackBaseElement of byte length `length`.
+
+    Args:
+        length (int): The byte length of stack_element.
+        stack_element (StackBaseElement): The stack element whose endianness should be reversed.
+            Defaults to `StackBaseElement(0)`.
+        rolling_option (bool): Whether stack_element should be rolled. Defaults to `True`.
+
+    """
+    out = move(stack_element, roll if rolling_option else pick)  # Move stack_element
     out += Script.parse_string(" ".join(["OP_1 OP_SPLIT"] * (length - 1)))
     out += Script.parse_string(" ".join(["OP_SWAP OP_CAT"] * (length - 1)))
     return out

--- a/tests/transaction_introspection/test_transaction_introspection.py
+++ b/tests/transaction_introspection/test_transaction_introspection.py
@@ -1,0 +1,117 @@
+import json
+from pathlib import Path
+
+import pytest
+from tx_engine import SIGHASH, Context, Tx, TxIn, hash256d, sig_hash_preimage
+
+from src.zkscript.transaction_introspection.transaction_introspection import TransactionIntrospection
+from src.zkscript.types.stack_elements import StackBaseElement
+
+prev_txid = int.to_bytes(34060536512648028283387372577505466741680559421950955299118826044926210663733, length=32).hex()
+prev_amount = 100
+
+
+def save_scripts(lock, unlock, save_to_json_folder, filename, test_name):
+    if save_to_json_folder:
+        output_dir = Path("data") / save_to_json_folder / "elliptic_curves"
+        output_dir.mkdir(parents=True, exist_ok=True)
+        json_file = output_dir / f"{filename}.json"
+
+        data = {}
+
+        if json_file.exists():
+            with json_file.open("r") as f:
+                data = json.load(f)
+
+        data[test_name] = {"lock": lock, "unlock": unlock}
+
+        with json_file.open("w") as f:
+            json.dump(data, f, indent=4)
+
+
+@pytest.mark.parametrize(
+    "sighash_value",
+    [
+        SIGHASH.ALL_FORKID,
+        SIGHASH.SINGLE_FORKID,
+        SIGHASH.NONE_FORKID,
+        SIGHASH.ALL_ANYONECANPAY_FORKID,
+        SIGHASH.NONE_ANYONECANPAY_FORKID,
+        SIGHASH.SINGLE_ANYONECANPAY_FORKID,
+    ],
+)
+@pytest.mark.parametrize("security", [2, 3])
+@pytest.mark.parametrize("is_opcodeseparator", [True, False])
+def test_pushtx_bit_shift(sighash_value, security, is_opcodeseparator, save_to_json_folder):
+    lock = TransactionIntrospection.pushtx_bit_shift(
+        sighash_value=sighash_value,
+        sig_hash_preimage=StackBaseElement(0),
+        rolling_option=1,
+        is_checksigverify=False,
+        is_opcodeseparator=is_opcodeseparator,
+        security=security,
+    )
+
+    tx_in = TxIn(prev_tx=prev_txid, prev_index=0, sequence=0)
+    tx = Tx(version=1, tx_ins=[tx_in], tx_outs=[], locktime=0)
+
+    tx, tx_in.script_sig = TransactionIntrospection.pushtx_bit_shift_unlock(
+        tx=tx, index=0, script_pubkey=lock, prev_amount=prev_amount, sighash_value=sighash_value, security=security
+    )
+
+    message = sig_hash_preimage(
+        tx=tx, index=0, script_pubkey=lock, prev_amount=prev_amount, sighash_value=sighash_value
+    )
+
+    context = Context(tx_in.script_sig + lock, z=hash256d(message))
+    assert context.evaluate()
+    assert len(context.get_stack()) == 1
+    assert len(context.get_altstack()) == 0
+
+    if save_to_json_folder:
+        save_scripts(
+            str(lock), str(tx_in.script_sig), save_to_json_folder, "transaction_introspection", "pushtx_bit_shift"
+        )
+
+
+@pytest.mark.parametrize(
+    "sighash_value",
+    [
+        SIGHASH.ALL_FORKID,
+        SIGHASH.SINGLE_FORKID,
+        SIGHASH.NONE_FORKID,
+        SIGHASH.ALL_ANYONECANPAY_FORKID,
+        SIGHASH.NONE_ANYONECANPAY_FORKID,
+        SIGHASH.SINGLE_ANYONECANPAY_FORKID,
+    ],
+)
+@pytest.mark.parametrize("is_opcodeseparator", [True, False])
+def test_pushtx(sighash_value, is_opcodeseparator, save_to_json_folder):
+    lock = TransactionIntrospection.pushtx(
+        sighash_value=sighash_value,
+        sig_hash_preimage=StackBaseElement(0),
+        rolling_option=1,
+        clean_constants=True,
+        verify_constants=True,
+        is_checksigverify=False,
+        is_opcodeseparator=is_opcodeseparator,
+    )
+
+    tx_in = TxIn(prev_tx=prev_txid, prev_index=0, sequence=0)
+    tx = Tx(version=1, tx_ins=[tx_in], tx_outs=[], locktime=0)
+
+    tx_in.script_sig = TransactionIntrospection.pushtx_unlock(
+        tx=tx, index=0, script_pubkey=lock, prev_amount=prev_amount, sighash_value=sighash_value, append_constants=True
+    )
+
+    message = sig_hash_preimage(
+        tx=tx, index=0, script_pubkey=lock, prev_amount=prev_amount, sighash_value=sighash_value
+    )
+
+    context = Context(tx_in.script_sig + lock, z=hash256d(message))
+    assert context.evaluate()
+    assert len(context.get_stack()) == 1
+    assert len(context.get_altstack()) == 0
+
+    if save_to_json_folder:
+        save_scripts(str(lock), str(tx_in.script_sig), save_to_json_folder, "transaction_introspection", "pushtx")

--- a/tests/transaction_introspection/test_transaction_introspection.py
+++ b/tests/transaction_introspection/test_transaction_introspection.py
@@ -6,6 +6,7 @@ from tx_engine import SIGHASH, Context, Tx, TxIn, hash256d, sig_hash_preimage
 
 from src.zkscript.transaction_introspection.transaction_introspection import TransactionIntrospection
 from src.zkscript.types.stack_elements import StackBaseElement
+from src.zkscript.types.unlocking_keys.transaction_introspection import PushTxBitShiftUnlockingKey, PushTxUnlockingKey
 
 prev_txid = int.to_bytes(34060536512648028283387372577505466741680559421950955299118826044926210663733, length=32).hex()
 prev_amount = 100
@@ -55,9 +56,9 @@ def test_pushtx_bit_shift(sighash_value, security, is_opcodeseparator, save_to_j
     tx_in = TxIn(prev_tx=prev_txid, prev_index=0, sequence=0)
     tx = Tx(version=1, tx_ins=[tx_in], tx_outs=[], locktime=0)
 
-    tx, tx_in.script_sig = TransactionIntrospection.pushtx_bit_shift_unlock(
-        tx=tx, index=0, script_pubkey=lock, prev_amount=prev_amount, sighash_value=sighash_value, security=security
-    )
+    unlocking_key = PushTxBitShiftUnlockingKey(tx=tx, index=0, script_pubkey=lock, prev_amount=prev_amount)
+
+    tx_in.script_sig = unlocking_key.to_unlocking_script(sighash_value=sighash_value, security=security)
 
     message = sig_hash_preimage(
         tx=tx, index=0, script_pubkey=lock, prev_amount=prev_amount, sighash_value=sighash_value
@@ -100,9 +101,9 @@ def test_pushtx(sighash_value, is_opcodeseparator, save_to_json_folder):
     tx_in = TxIn(prev_tx=prev_txid, prev_index=0, sequence=0)
     tx = Tx(version=1, tx_ins=[tx_in], tx_outs=[], locktime=0)
 
-    tx_in.script_sig = TransactionIntrospection.pushtx_unlock(
-        tx=tx, index=0, script_pubkey=lock, prev_amount=prev_amount, sighash_value=sighash_value, append_constants=True
-    )
+    unlocking_key = PushTxUnlockingKey(tx=tx, index=0, script_pubkey=lock, prev_amount=prev_amount)
+
+    tx_in.script_sig = unlocking_key.to_unlocking_script(sighash_value=sighash_value, append_constants=True)
 
     message = sig_hash_preimage(
         tx=tx, index=0, script_pubkey=lock, prev_amount=prev_amount, sighash_value=sighash_value

--- a/tests/utility_scripts/test_utility_scripts.py
+++ b/tests/utility_scripts/test_utility_scripts.py
@@ -1,13 +1,17 @@
 import pytest
-from tx_engine import Context, Script
+from tx_engine import Context, Script, encode_num
+from tx_engine.engine.util import GROUP_ORDER_INT
 
 from src.zkscript.types.stack_elements import StackBaseElement, StackNumber
 from src.zkscript.util.utility_scripts import (
+    bytes_to_unsigned,
+    int_sig_to_s_component,
     mod,
     move,
     nums_to_script,
     pick,
     reverse_endianness,
+    reverse_endianness_unknown_length,
     roll,
     verify_bottom_constant,
 )
@@ -219,6 +223,189 @@ def test_reverse_endianness(stack, length, stack_element, rolling_option, expect
         unlock.append_pushdata(bytes.fromhex(el))
 
     lock = reverse_endianness(length, stack_element, rolling_option)
+    for ix, el in enumerate(expected[::-1]):
+        lock.append_pushdata(bytes.fromhex(el))
+        lock += Script.parse_string("OP_EQUAL" if ix == len(expected) - 1 else "OP_EQUALVERIFY")
+
+    context = Context(unlock + lock)
+    assert context.evaluate()
+    assert len(context.get_stack()) == 1
+
+
+@pytest.mark.parametrize(
+    ("stack", "max_length", "stack_element", "rolling_option", "expected"),
+    [
+        (
+            ["01", "02", "03", "04", "aabbccddeeff"],
+            10,
+            StackBaseElement(0),
+            True,
+            ["01", "02", "03", "04", "ffeeddccbbaa"],
+        ),
+        (["01", "02", "aabbccddee", "03", "04"], 8, StackBaseElement(2), True, ["01", "02", "03", "04", "eeddccbbaa"]),
+        (
+            ["aabbccdd", "01", "02", "03", "04"],
+            6,
+            StackBaseElement(-1),
+            False,
+            ["aabbccdd", "01", "02", "03", "04", "ddccbbaa"],
+        ),
+    ],
+)
+def test_reverse_endianness_unknown_length(stack, max_length, stack_element, rolling_option, expected):
+    unlock = Script()
+    for el in stack:
+        unlock.append_pushdata(bytes.fromhex(el))
+
+    lock = reverse_endianness_unknown_length(max_length, stack_element, rolling_option)
+    for ix, el in enumerate(expected[::-1]):
+        lock.append_pushdata(bytes.fromhex(el))
+        lock += Script.parse_string("OP_EQUAL" if ix == len(expected) - 1 else "OP_EQUALVERIFY")
+
+    context = Context(unlock + lock)
+    assert context.evaluate()
+    assert len(context.get_stack()) == 1
+
+
+@pytest.mark.parametrize("add_prefix", [True, False])
+@pytest.mark.parametrize(
+    ("stack", "group_order", "stack_element", "rolling_options", "expected"),
+    [
+        (
+            [
+                bytes.fromhex("01"),
+                encode_num(GROUP_ORDER_INT),
+                encode_num(23273337322559462728397485925482564225812377166088316918328726254919566391069),  # sig
+            ],
+            StackNumber(1, False),
+            StackNumber(0, False),
+            3,
+            [
+                bytes.fromhex("01"),
+                (23273337322559462728397485925482564225812377166088316918328726254919566391069).to_bytes(32),
+            ],
+        ),
+        (
+            [
+                bytes.fromhex("01"),
+                encode_num(23273337322559462728397485925482564225812377166088316918328726254919566391069),  # sig
+                encode_num(GROUP_ORDER_INT),
+            ],
+            StackNumber(0, False),
+            StackNumber(1, False),
+            3,
+            [
+                bytes.fromhex("01"),
+                (23273337322559462728397485925482564225812377166088316918328726254919566391069).to_bytes(32),
+            ],
+        ),
+        (
+            [
+                encode_num(GROUP_ORDER_INT),
+                bytes.fromhex("01"),
+                encode_num(23273337322559462728397485925482564225812377166088316918328726254919566391069),  # sig
+            ],
+            StackNumber(-1, False),
+            StackNumber(0, False),
+            3,
+            [
+                bytes.fromhex("01"),
+                (23273337322559462728397485925482564225812377166088316918328726254919566391069).to_bytes(32),
+            ],
+        ),
+        (
+            [
+                bytes.fromhex("01"),
+                encode_num(GROUP_ORDER_INT),
+                encode_num(23273337322559462728397485925482564225812377166088316918328726254919566391069),  # sig
+            ],
+            StackNumber(1, False),
+            StackNumber(0, False),
+            0,
+            [
+                bytes.fromhex("01"),
+                encode_num(GROUP_ORDER_INT),
+                encode_num(23273337322559462728397485925482564225812377166088316918328726254919566391069),  # sig
+                (23273337322559462728397485925482564225812377166088316918328726254919566391069).to_bytes(32),
+            ],
+        ),
+        (
+            [
+                bytes.fromhex("01"),
+                encode_num(GROUP_ORDER_INT),
+                encode_num(23273337322559462728397485925482564225812377166088316918328726254919566391069),  # sig
+                bytes.fromhex("02"),
+            ],
+            StackNumber(2, False),
+            StackNumber(1, False),
+            0,
+            [
+                bytes.fromhex("01"),
+                encode_num(GROUP_ORDER_INT),
+                encode_num(23273337322559462728397485925482564225812377166088316918328726254919566391069),  # sig
+                bytes.fromhex("02"),
+                (23273337322559462728397485925482564225812377166088316918328726254919566391069).to_bytes(32),
+            ],
+        ),
+        (
+            [
+                bytes.fromhex("01"),
+                encode_num(GROUP_ORDER_INT),
+                encode_num(208306889145243764628110735254800045248183311764997803938817302883604514149),  # sig
+            ],
+            StackNumber(1, False),
+            StackNumber(0, False),
+            3,
+            [
+                bytes.fromhex("01"),
+                (208306889145243764628110735254800045248183311764997803938817302883604514149).to_bytes(31),
+            ],
+        ),
+        (
+            [
+                bytes.fromhex("01"),
+                encode_num(GROUP_ORDER_INT),
+                encode_num(GROUP_ORDER_INT // 2 + 100),  # sig
+            ],
+            StackNumber(1, False),
+            StackNumber(0, False),
+            3,
+            [bytes.fromhex("01"), (GROUP_ORDER_INT - (GROUP_ORDER_INT // 2 + 100)).to_bytes(32)],
+        ),
+    ],
+)
+def test_int_sig_to_s_component(stack, group_order, stack_element, rolling_options, add_prefix, expected):
+    unlock = Script()
+    for el in stack:
+        unlock.append_pushdata(el)
+
+    lock = int_sig_to_s_component(group_order, stack_element, rolling_options, add_prefix)
+    for ix, el in enumerate(expected[::-1]):
+        lock.append_pushdata(el if ix != 0 or not add_prefix else bytes.fromhex("02" + hex(len(el))[2:]) + el)
+        lock += Script.parse_string("OP_EQUAL" if ix == len(expected) - 1 else "OP_EQUALVERIFY")
+
+    context = Context(unlock + lock)
+    assert context.evaluate()
+    assert len(context.get_stack()) == 1
+
+
+@pytest.mark.parametrize(
+    ("stack", "stack_element", "rolling_option", "expected"),
+    [
+        (["01", "02"], StackNumber(0, False), True, ["01", "02"]),
+        (["01", "02"], StackNumber(0, False), False, ["01", "02", "02"]),
+        (["01", "0280"], StackNumber(0, False), True, ["01", "028000"]),
+        (["01", "0280"], StackNumber(0, False), False, ["01", "0280", "028000"]),
+        (["01", "02"], StackNumber(1, False), True, ["02", "01"]),
+        (["01ff", "02"], StackNumber(1, False), False, ["01ff", "02", "01ff00"]),
+    ],
+)
+def test_bytes_to_unsigned(stack, stack_element, rolling_option, expected):
+    unlock = Script()
+    for el in stack:
+        unlock.append_pushdata(bytes.fromhex(el))
+
+    lock = bytes_to_unsigned(stack_element, rolling_option)
     for ix, el in enumerate(expected[::-1]):
         lock.append_pushdata(bytes.fromhex(el))
         lock += Script.parse_string("OP_EQUAL" if ix == len(expected) - 1 else "OP_EQUALVERIFY")

--- a/tests/utility_scripts/test_utility_scripts.py
+++ b/tests/utility_scripts/test_utility_scripts.py
@@ -392,12 +392,12 @@ def test_int_sig_to_s_component(stack, group_order, stack_element, rolling_optio
 @pytest.mark.parametrize(
     ("stack", "stack_element", "rolling_option", "expected"),
     [
-        (["01", "02"], StackNumber(0, False), True, ["01", "02"]),
-        (["01", "02"], StackNumber(0, False), False, ["01", "02", "02"]),
-        (["01", "0280"], StackNumber(0, False), True, ["01", "028000"]),
-        (["01", "0280"], StackNumber(0, False), False, ["01", "0280", "028000"]),
-        (["01", "02"], StackNumber(1, False), True, ["02", "01"]),
-        (["01ff", "02"], StackNumber(1, False), False, ["01ff", "02", "01ff00"]),
+        (["01", "02"], StackBaseElement(0), True, ["01", "02"]),
+        (["01", "02"], StackBaseElement(0), False, ["01", "02", "02"]),
+        (["01", "0280"], StackBaseElement(0), True, ["01", "028000"]),
+        (["01", "0280"], StackBaseElement(0), False, ["01", "0280", "028000"]),
+        (["01", "02"], StackBaseElement(1), True, ["02", "01"]),
+        (["01ff", "02"], StackBaseElement(1), False, ["01ff", "02", "01ff00"]),
     ],
 )
 def test_bytes_to_unsigned(stack, stack_element, rolling_option, expected):


### PR DESCRIPTION
Changes include:
* Construct two scripts that achieve transaction introspection (`pushtx` and `pushtx_bit_shift`)
* Minor fixes (`script.py`)
* Construct new utility scripts: `reverse_endianness`, `reverse_endianness_unknown_length`, `bytes_to_unsigned`, `int_sig_to_s_component`