### PR TITLE
Perf/negative modulo in verify gradient ec 47

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ The script sizes for Groth16 are:
 
 | Curve | # public statements | Unlocking script size | Locking script size | Modulo threshold | Total |
 | ----- | ------------------- | --------------------- | ------------------- | ---------------- | ----- |
-| `BLS12-381` | 2 | ~ 59 KB | ~ 426 KB | 200B | ~ 485 KB |
-| `MNT4-753` | 1 | ~ 402 KB | ~ 488 KB | 200B | ~ 890 KB |
+| `BLS12-381` | 2 | ~ 59 KB | ~ 436 KB | 200B | ~ 495 KB |
+| `MNT4-753` | 1 | ~ 402 KB | ~ 498 KB | 200B | ~ 900 KB |
 
 Note: the unlocking script is dependent on the public statements.
 

--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ The script sizes for Groth16 are:
 
 | Curve | # public statements | Unlocking script size | Locking script size | Modulo threshold | Total |
 | ----- | ------------------- | --------------------- | ------------------- | ---------------- | ----- |
-| `BLS12-381` | 2 | ~ 59 KB | ~ 440 KB | 200B | ~ 499 KB |
-| `MNT4-753` | 1 | ~ 402 KB | ~ 508 KB | 200B | ~ 910 KB |
+| `BLS12-381` | 2 | ~ 59 KB | ~ 426 KB | 200B | ~ 485 KB |
+| `MNT4-753` | 1 | ~ 402 KB | ~ 488 KB | 200B | ~ 890 KB |
 
 Note: the unlocking script is dependent on the public statements.
 

--- a/src/zkscript/elliptic_curves/ec_operations_fq.py
+++ b/src/zkscript/elliptic_curves/ec_operations_fq.py
@@ -300,7 +300,7 @@ class EllipticCurveFq:
         else:
             verify_gradient += Script.parse_string("OP_ADD")  # Compute gradient *(xP - xQ) - (yP_ - yQ_)
         verify_gradient += roll(position=-1, n_elements=1) if clean_constant else pick(position=-1, n_elements=1)
-        verify_gradient += mod(stack_preparation="")
+        verify_gradient += mod(stack_preparation="", is_positive=False)
         verify_gradient += Script.parse_string("OP_0 OP_EQUALVERIFY")
         verify_gradient += Script.parse_string("OP_TOALTSTACK" if take_modulo else "OP_DROP")
 
@@ -538,7 +538,7 @@ class EllipticCurveFq:
             verify_gradient += Script.parse_string("OP_ADD")
         verify_gradient += Script.parse_string("OP_ADD" if P.y.negate else "OP_SUB")
         verify_gradient += roll(position=-1, n_elements=1) if clean_constant else pick(position=-1, n_elements=1)
-        verify_gradient += mod(stack_preparation="")
+        verify_gradient += mod(stack_preparation="", is_positive=False)
         verify_gradient += Script.parse_string("OP_0 OP_EQUALVERIFY")
         verify_gradient += Script.parse_string("OP_TOALTSTACK" if take_modulo else "OP_DROP")
 
@@ -799,12 +799,12 @@ class EllipticCurveFq:
             batched_modulo += Script.parse_string("OP_FROMALTSTACK OP_ROT")
             out += batched_modulo
 
-        check_gradient = Script.parse_string("OP_FROMALTSTACK")
-        check_gradient += mod(stack_preparation="", is_mod_on_top=False, is_constant_reused=False, is_positive=True)
-        check_gradient += Script.parse_string("OP_0 OP_EQUALVERIFY")
+        verify_gradient = Script.parse_string("OP_FROMALTSTACK")
+        verify_gradient += mod(stack_preparation="", is_mod_on_top=False, is_constant_reused=False, is_positive=False)
+        verify_gradient += Script.parse_string("OP_0 OP_EQUALVERIFY")
 
         # Check gradient was correct
-        out += check_gradient
+        out += verify_gradient
 
         # Termination conditions  --------------------------------------------------------------------------------------
 

--- a/src/zkscript/elliptic_curves/ec_operations_fq2.py
+++ b/src/zkscript/elliptic_curves/ec_operations_fq2.py
@@ -351,7 +351,11 @@ class EllipticCurveFq2:
         verify_gradient += roll(position=2, n_elements=1)  # Bring [(yQ_)_1 - (yP_)_1] on top
         verify_gradient += roll(position=5, n_elements=2)  # Bring [gradient * (xP - xQ)] on top
         verify_gradient += fq2.add(
-            take_modulo=True, check_constant=False, clean_constant=False, is_constant_reused=False
+            take_modulo=True,
+            check_constant=False,
+            clean_constant=False,
+            is_constant_reused=False,
+            positive_modulo=False,
         )  # Compute gradient * (x_P - x_Q) + (yQ_ - yP_)
         verify_gradient += Script.parse_string("OP_CAT OP_0 OP_EQUALVERIFY")
 
@@ -665,7 +669,11 @@ class EllipticCurveFq2:
             verify_gradient += Script.parse_string("OP_ADD")  # Compute 3 * (xP^2)_1 + a_1
         verify_gradient += Script.parse_string("OP_FROMALTSTACK")
         verify_gradient += fq2.subtract(
-            take_modulo=True, check_constant=False, clean_constant=False, is_constant_reused=False
+            take_modulo=True,
+            check_constant=False,
+            clean_constant=False,
+            is_constant_reused=False,
+            positive_modulo=False,
         )  # Compute 2*gradient*yP_ - (3xP^2 + a)
         verify_gradient += Script.parse_string("OP_CAT OP_0 OP_EQUALVERIFY")
 

--- a/tests/groth16/test_groth16.py
+++ b/tests/groth16/test_groth16.py
@@ -433,7 +433,7 @@ def test_groth16_slow(
     )
     lock = test_script.groth16_verifier(
         locking_key,
-        modulo_threshold=500 * 8,
+        modulo_threshold=200 * 8,
         max_multipliers=max_multipliers,
         check_constant=True,
         clean_constant=True,

--- a/tests/groth16/test_groth16.py
+++ b/tests/groth16/test_groth16.py
@@ -433,7 +433,7 @@ def test_groth16_slow(
     )
     lock = test_script.groth16_verifier(
         locking_key,
-        modulo_threshold=200 * 8,
+        modulo_threshold=500 * 8,
         max_multipliers=max_multipliers,
         check_constant=True,
         clean_constant=True,


### PR DESCRIPTION
Changes include:
- take negative modulos when using op_equalverify to compare with 0