### PR TITLE
perf: postpone gradient commitment verification in Groth16

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ The script sizes for Groth16 are:
 
 | Curve | # public statements | Unlocking script size | Locking script size | Modulo threshold | Total |
 | ----- | ------------------- | --------------------- | ------------------- | ---------------- | ----- |
-| `BLS12-381` | 2 | ~ 59 KB | ~ 436 KB | 200B | ~ 495 KB |
-| `MNT4-753` | 1 | ~ 402 KB | ~ 498 KB | 200B | ~ 900 KB |
+| `BLS12-381` | 2 | ~ 59 KB | ~ 435 KB | 200B | ~ 494 KB |
+| `MNT4-753` | 1 | ~ 402 KB | ~ 495 KB | 200B | ~ 897 KB |
 
 Note: the unlocking script is dependent on the public statements.
 

--- a/src/zkscript/bilinear_pairings/bls12_381/final_exponentiation.py
+++ b/src/zkscript/bilinear_pairings/bls12_381/final_exponentiation.py
@@ -69,7 +69,9 @@ class FinalExponentiation(CyclotomicExponentiation):
         """
         # Fq12 implementation
         fq12 = self.FQ12
-        is_default_config = (f_inverse.position == self.EXTENSION_DEGREE * 2 - 1) and (f.position == self.EXTENSION_DEGREE -1)
+        is_default_config = (f_inverse.position == self.EXTENSION_DEGREE * 2 - 1) and (
+            f.position == self.EXTENSION_DEGREE - 1
+        )
 
         out = verify_bottom_constant(self.MODULUS) if check_constant else Script()
 

--- a/src/zkscript/bilinear_pairings/bls12_381/final_exponentiation.py
+++ b/src/zkscript/bilinear_pairings/bls12_381/final_exponentiation.py
@@ -6,7 +6,7 @@ from src.zkscript.bilinear_pairings.bls12_381.fields import fq12_script, fq12cub
 from src.zkscript.bilinear_pairings.bls12_381.parameters import exp_miller_loop
 from src.zkscript.bilinear_pairings.model.cyclotomic_exponentiation import CyclotomicExponentiation
 from src.zkscript.types.stack_elements import StackFiniteFieldElement
-from src.zkscript.util.utility_scripts import pick, roll, verify_bottom_constant
+from src.zkscript.util.utility_scripts import move, pick, roll, verify_bottom_constant
 
 
 class FinalExponentiation(CyclotomicExponentiation):
@@ -33,14 +33,14 @@ class FinalExponentiation(CyclotomicExponentiation):
         check_constant: bool | None = None,
         clean_constant: bool | None = None,
         is_constant_reused: bool | None = None,
-        f: StackFiniteFieldElement = StackFiniteFieldElement(11, False, 12),  # noqa: B008
         f_inverse: StackFiniteFieldElement = StackFiniteFieldElement(23, False, 12),  # noqa: B008
+        f: StackFiniteFieldElement = StackFiniteFieldElement(11, False, 12),  # noqa: B008
     ) -> Script:
         """Easy part of the final exponentiation.
 
         Stack input:
-            - stack:    [q, ..., inverse(f_quadratic), f], `f` is an element in F_q^12, the cubic extension of F_q^4,
-                `f_quadratic` is the same element in the quadratic extension of F_q^6, and its inverse is also an
+            - stack:    [q, ..., inverse(f_quadratic), ..., f, ...], `f` is an element in F_q^12, the cubic extension of
+                F_q^4, `f_quadratic` is the same element in the quadratic extension of F_q^6, and its inverse is also an
                 element in the quadratic extension of F_q^6
             - altstack: []
 
@@ -55,10 +55,10 @@ class FinalExponentiation(CyclotomicExponentiation):
             clean_constant (bool | None): If `True`, remove `q` from the bottom of the stack. Defaults to `None`.
             is_constant_reused (bool | None, optional): If `True`, `q` remains as the second-to-top element on the stack
                 after execution. Defaults to `None`.
-            f (StackFiniteFieldElement): the value `f`. Default to
-                StackFiniteFieldElement = StackFiniteFieldElement(11, False, 12).
-            f_inverse (StackFiniteFieldElement): the value `f_inverse`. Default to
+            f_inverse (StackFiniteFieldElement): the value `f_inverse`. Defaults to
                 StackFiniteFieldElement = StackFiniteFieldElement(23, False, 12).
+            f (StackFiniteFieldElement): the value `f`. Defaults to
+                StackFiniteFieldElement = StackFiniteFieldElement(11, False, 12).
 
         Returns:
             Script to perform the easy part of the exponentiation in the pairing for BLS12-381.
@@ -69,15 +69,14 @@ class FinalExponentiation(CyclotomicExponentiation):
         """
         # Fq12 implementation
         fq12 = self.FQ12
+        is_default_config = (f_inverse.position == self.EXTENSION_DEGREE * 2 - 1) and (f.position == self.EXTENSION_DEGREE -1)
 
         out = verify_bottom_constant(self.MODULUS) if check_constant else Script()
 
         # After this, the stack is: Inverse(f_quadratic) f
-        if f_inverse == StackFiniteFieldElement(11, False, 12):
-            out += roll(position=f.position, n_elements=f.extension_degree)
-        elif f != StackFiniteFieldElement(11, False, 12) or f_inverse != StackFiniteFieldElement(23, False, 12):
-            out += roll(position=f_inverse.position, n_elements=f_inverse.extension_degree)
-            out += roll(position=f.position + self.EXTENSION_DEGREE, n_elements=f.extension_degree)
+        if not is_default_config:
+            out += move(f_inverse, roll)
+            out += move(f.shift(f_inverse.extension_degree * f_inverse.is_before(f)), roll)
 
         # After this, the stack is: Inverse(f_quadratic) f_quadratic
         check_f_inverse = pick(position=23, n_elements=12)  # Bring Inverse(f_quadratic) on top of the stack

--- a/src/zkscript/bilinear_pairings/bls12_381/line_functions.py
+++ b/src/zkscript/bilinear_pairings/bls12_381/line_functions.py
@@ -70,7 +70,7 @@ class LineFunctions:
                     StackFiniteFieldElement(1, False, 2),
                 )`
             rolling_options (int): Bitmask detailing which elements among `gradient`, `P`, and `Q` should be rolled.
-                Default to 7 (everything is rolled).
+                Defaults to 7 (everything is rolled).
 
         Preconditions:
             - `gradient` is the gradient through `T` and `Q`.

--- a/src/zkscript/bilinear_pairings/mnt4_753/final_exponentiation.py
+++ b/src/zkscript/bilinear_pairings/mnt4_753/final_exponentiation.py
@@ -37,7 +37,6 @@ class FinalExponentiation(CyclotomicExponentiation):
         is_constant_reused: bool | None = None,
         f_inverse: StackFiniteFieldElement = StackFiniteFieldElement(7, False, 4),  # noqa: B008
         f: StackFiniteFieldElement = StackFiniteFieldElement(3, False, 4),  # noqa: B008
-
     ) -> Script:
         """Easy part of the final exponentiation.
 
@@ -69,7 +68,9 @@ class FinalExponentiation(CyclotomicExponentiation):
         """
         fq4 = self.FQ4
 
-        is_default_config = (f_inverse.position == self.EXTENSION_DEGREE * 2 - 1) and (f.position == self.EXTENSION_DEGREE -1)
+        is_default_config = (f_inverse.position == self.EXTENSION_DEGREE * 2 - 1) and (
+            f.position == self.EXTENSION_DEGREE - 1
+        )
 
         out = verify_bottom_constant(self.MODULUS) if check_constant else Script()
 

--- a/src/zkscript/bilinear_pairings/mnt4_753/final_exponentiation.py
+++ b/src/zkscript/bilinear_pairings/mnt4_753/final_exponentiation.py
@@ -6,7 +6,7 @@ from src.zkscript.bilinear_pairings.mnt4_753.fields import fq2_script, fq4_scrip
 from src.zkscript.bilinear_pairings.mnt4_753.parameters import exp_miller_loop
 from src.zkscript.bilinear_pairings.model.cyclotomic_exponentiation import CyclotomicExponentiation
 from src.zkscript.types.stack_elements import StackFiniteFieldElement
-from src.zkscript.util.utility_scripts import pick, roll, verify_bottom_constant
+from src.zkscript.util.utility_scripts import move, pick, roll, verify_bottom_constant
 
 
 class FinalExponentiation(CyclotomicExponentiation):
@@ -35,14 +35,14 @@ class FinalExponentiation(CyclotomicExponentiation):
         check_constant: bool | None = None,
         clean_constant: bool | None = None,
         is_constant_reused: bool | None = None,
-        f: StackFiniteFieldElement = StackFiniteFieldElement(3, False, 4),  # noqa: B008
         f_inverse: StackFiniteFieldElement = StackFiniteFieldElement(7, False, 4),  # noqa: B008
+        f: StackFiniteFieldElement = StackFiniteFieldElement(3, False, 4),  # noqa: B008
 
     ) -> Script:
         """Easy part of the final exponentiation.
 
         Stack input:
-            - stack:    [q, ..., inverse(f), f], `f` and `inverse(f)` are elements in F_q^4
+            - stack:    [q, ..., inverse(f), ..., f, ...], `f` and `inverse(f)` are elements in F_q^4
             - altstack: []
 
         Stack output:
@@ -56,10 +56,10 @@ class FinalExponentiation(CyclotomicExponentiation):
             clean_constant (bool | None): If `True`, remove `q` from the bottom of the stack. Defaults to `None`.
             is_constant_reused (bool | None, optional): If `True`, `q` remains as the second-to-top element on the stack
                 after execution. Defaults to `None`.
-            f (StackFiniteFieldElement): the value `f`. Default to
-                StackFiniteFieldElement = StackFiniteFieldElement(3, False, 4).
-            f_inverse (StackFiniteFieldElement): the value `f_inverse`. Default to
+            f_inverse (StackFiniteFieldElement): the value `f_inverse`. Defaults to
                 StackFiniteFieldElement = StackFiniteFieldElement(7, False, 4).
+            f (StackFiniteFieldElement): the value `f`. Defaults to
+                StackFiniteFieldElement = StackFiniteFieldElement(3, False, 4).
 
         Returns:
             Script to perform the easy part of the exponentiation in the pairing for MNT4-753.
@@ -69,14 +69,14 @@ class FinalExponentiation(CyclotomicExponentiation):
         """
         fq4 = self.FQ4
 
+        is_default_config = (f_inverse.position == self.EXTENSION_DEGREE * 2 - 1) and (f.position == self.EXTENSION_DEGREE -1)
+
         out = verify_bottom_constant(self.MODULUS) if check_constant else Script()
 
         # After this, the stack is: Inverse(f) f
-        if f_inverse == StackFiniteFieldElement(3, False, 4):
-            out += roll(position=f.position, n_elements=f.extension_degree)
-        elif f != StackFiniteFieldElement(3, False, 4) or f_inverse != StackFiniteFieldElement(7, False, 4):
-            out += roll(position=f_inverse.position, n_elements=f_inverse.extension_degree)
-            out += roll(position=f.position + self.EXTENSION_DEGREE, n_elements=f.extension_degree)
+        if not is_default_config:
+            out += move(f_inverse, roll)
+            out += move(f.shift(f_inverse.extension_degree * f_inverse.is_before(f)), roll)
 
         # After this, the stack is: Inverse(f) f
         check_f_inverse = pick(position=7, n_elements=4)  # Bring Inverse(f) on top of the stack

--- a/src/zkscript/bilinear_pairings/mnt4_753/final_exponentiation.py
+++ b/src/zkscript/bilinear_pairings/mnt4_753/final_exponentiation.py
@@ -5,7 +5,8 @@ from tx_engine import Script
 from src.zkscript.bilinear_pairings.mnt4_753.fields import fq2_script, fq4_script
 from src.zkscript.bilinear_pairings.mnt4_753.parameters import exp_miller_loop
 from src.zkscript.bilinear_pairings.model.cyclotomic_exponentiation import CyclotomicExponentiation
-from src.zkscript.util.utility_scripts import pick, verify_bottom_constant
+from src.zkscript.types.stack_elements import StackFiniteFieldElement
+from src.zkscript.util.utility_scripts import pick, roll, verify_bottom_constant
 
 
 class FinalExponentiation(CyclotomicExponentiation):
@@ -34,6 +35,9 @@ class FinalExponentiation(CyclotomicExponentiation):
         check_constant: bool | None = None,
         clean_constant: bool | None = None,
         is_constant_reused: bool | None = None,
+        f: StackFiniteFieldElement = StackFiniteFieldElement(3, False, 4),  # noqa: B008
+        f_inverse: StackFiniteFieldElement = StackFiniteFieldElement(7, False, 4),  # noqa: B008
+
     ) -> Script:
         """Easy part of the final exponentiation.
 
@@ -52,6 +56,10 @@ class FinalExponentiation(CyclotomicExponentiation):
             clean_constant (bool | None): If `True`, remove `q` from the bottom of the stack. Defaults to `None`.
             is_constant_reused (bool | None, optional): If `True`, `q` remains as the second-to-top element on the stack
                 after execution. Defaults to `None`.
+            f (StackFiniteFieldElement): the value `f`. Default to
+                StackFiniteFieldElement = StackFiniteFieldElement(3, False, 4).
+            f_inverse (StackFiniteFieldElement): the value `f_inverse`. Default to
+                StackFiniteFieldElement = StackFiniteFieldElement(7, False, 4).
 
         Returns:
             Script to perform the easy part of the exponentiation in the pairing for MNT4-753.
@@ -62,6 +70,13 @@ class FinalExponentiation(CyclotomicExponentiation):
         fq4 = self.FQ4
 
         out = verify_bottom_constant(self.MODULUS) if check_constant else Script()
+
+        # After this, the stack is: Inverse(f) f
+        if f_inverse == StackFiniteFieldElement(3, False, 4):
+            out += roll(position=f.position, n_elements=f.extension_degree)
+        elif f != StackFiniteFieldElement(3, False, 4) or f_inverse != StackFiniteFieldElement(7, False, 4):
+            out += roll(position=f_inverse.position, n_elements=f_inverse.extension_degree)
+            out += roll(position=f.position + self.EXTENSION_DEGREE, n_elements=f.extension_degree)
 
         # After this, the stack is: Inverse(f) f
         check_f_inverse = pick(position=7, n_elements=4)  # Bring Inverse(f) on top of the stack

--- a/src/zkscript/bilinear_pairings/mnt4_753/line_functions.py
+++ b/src/zkscript/bilinear_pairings/mnt4_753/line_functions.py
@@ -69,7 +69,7 @@ class LineFunctions:
                     StackFiniteFieldElement(1, False, 2),
                 )`
             rolling_options (int): Bitmask detailing which elements among `gradient`, `P`, and `Q` should be rolled.
-                Default to 7 (everything is rolled).
+                Defaults to 7 (everything is rolled).
 
         Preconditions:
             - `gradient` is the gradient through `T` and `Q`.

--- a/src/zkscript/bilinear_pairings/model/miller_loop.py
+++ b/src/zkscript/bilinear_pairings/model/miller_loop.py
@@ -92,7 +92,7 @@ class MillerLoop:
             verify_gradient=verify_gradient,
             gradient=gradient_doubling,
             P=T,
-            rolling_options=3,
+            rolling_options=boolean_list_to_bitmask([verify_gradient, True]),
         )
         # stack in:    [..., P, Q, 2T]
         # altstack in: [({f_i^2} * ev_(l_(T,T))(P))]
@@ -215,7 +215,7 @@ class MillerLoop:
             verify_gradient=verify_gradients,
             gradient=gradient_doubling,
             P=T,
-            rolling_options=boolean_list_to_bitmask([verify_gradients,True]),
+            rolling_options=boolean_list_to_bitmask([verify_gradients, True]),
         )  # Compute 2T
         # stack in:     [gradient_(2T ± Q), ..., P, Q, 2T]
         # altstack in:  [({f_i^2} * ev_(l_(T,T))(P) * ev_(l_(2T, ± Q))(P))^2]
@@ -230,7 +230,7 @@ class MillerLoop:
             gradient=gradient_addition.shift(-self.EXTENSION_DEGREE if verify_gradients else 0),
             P=Q.set_negate(self.exp_miller_loop[i] == -1),
             Q=T,
-            rolling_options=boolean_list_to_bitmask([verify_gradients,False, True]),
+            rolling_options=boolean_list_to_bitmask([verify_gradients, False, True]),
         )  # Compute (2T ± Q)
         # stack in:     [P, Q, (2T ± Q)]
         # altstack in:  [({f_i^2} * ev_(l_(T,T))(P) * ev_(l_(2T, ± Q))(P))^2]
@@ -426,7 +426,7 @@ class MillerLoop:
                     Q=Q,
                     T=T,
                 )
-                gradient_tracker += 2*self.EXTENSION_DEGREE if not verify_gradients else 0
+                gradient_tracker += 2 * self.EXTENSION_DEGREE if not verify_gradients else 0
         # stack in:  [P, Q, w*Q, miller(P,Q)]
         # stack out: [w*Q, miller(P,Q)]
         out += move(Q.shift(self.N_ELEMENTS_MILLER_OUTPUT), roll)  # Roll Q

--- a/src/zkscript/bilinear_pairings/model/miller_loop.py
+++ b/src/zkscript/bilinear_pairings/model/miller_loop.py
@@ -5,7 +5,7 @@ from math import ceil, log2
 from tx_engine import Script
 
 from src.zkscript.types.stack_elements import StackEllipticCurvePoint, StackFiniteFieldElement
-from src.zkscript.util.utility_functions import optimise_script
+from src.zkscript.util.utility_functions import boolean_list_to_bitmask, optimise_script
 from src.zkscript.util.utility_scripts import move, pick, roll, verify_bottom_constant
 
 
@@ -82,7 +82,7 @@ class MillerLoop:
         )
         # stack in:     [gradient_(2T), P, Q, T]
         # altstack in:  [({f_i^2} * ev_(l_(T,T))(P))]
-        # stack out:    [P, Q, 2T]
+        # stack out:    [gradient_(2T) if not verify_gradient, P, Q, 2T]
         # altstack out: [({f_i^2} * ev_(l_(T,T))(P))]
         out += self.point_doubling_twisted_curve(
             take_modulo=take_modulo[1],
@@ -94,9 +94,9 @@ class MillerLoop:
             P=T,
             rolling_options=3,
         )
-        # stack in:    [P, Q, 2T]
+        # stack in:    [..., P, Q, 2T]
         # altstack in: [({f_i^2} * ev_(l_(T,T))(P))]
-        # stack out:   [P, Q, 2T, ({f_i^2} * ev_(l_(T,T))(P))]
+        # stack out:   [..., P, Q, 2T, ({f_i^2} * ev_(l_(T,T))(P))]
         out += Script.parse_string(
             " ".join(
                 ["OP_FROMALTSTACK"]
@@ -205,7 +205,7 @@ class MillerLoop:
         )
         # stack in:     [gradient_(2T ± Q), gradient_(2T), P, Q, T]
         # altstack in:  [({f_i^2} * ev_(l_(T,T))(P) * ev_(l_(2T, ± Q))(P))^2]
-        # stack out:    [gradient_(2T ± Q), P, Q, 2T]
+        # stack out:    [gradient_(2T ± Q), gradient_(2T) if not verify_gradients, P, Q, 2T]
         # altstack out: [({f_i^2} * ev_(l_(T,T))(P) * ev_(l_(2T, ± Q))(P))^2]
         out += self.point_doubling_twisted_curve(
             take_modulo=False,
@@ -215,11 +215,11 @@ class MillerLoop:
             verify_gradient=verify_gradients,
             gradient=gradient_doubling,
             P=T,
-            rolling_options=3,
+            rolling_options=boolean_list_to_bitmask([verify_gradients,True]),
         )  # Compute 2T
-        # stack in:     [gradient_(2T ± Q), P, Q, 2T]
+        # stack in:     [gradient_(2T ± Q), ..., P, Q, 2T]
         # altstack in:  [({f_i^2} * ev_(l_(T,T))(P) * ev_(l_(2T, ± Q))(P))^2]
-        # stack out:    [P, Q, (2T ± Q)]
+        # stack out:    [gradient_(2T ± Q) if not verify_gradients, ..., P, Q, (2T ± Q)]
         # altstack out: [({f_i^2} * ev_(l_(T,T))(P) * ev_(l_(2T, ± Q))(P))^2]
         out += self.point_addition_twisted_curve(
             take_modulo=take_modulo[1],
@@ -227,10 +227,10 @@ class MillerLoop:
             check_constant=False,
             clean_constant=(i == 0) and clean_constant,
             verify_gradient=verify_gradients,
-            gradient=gradient_addition.shift(-self.EXTENSION_DEGREE),
+            gradient=gradient_addition.shift(-self.EXTENSION_DEGREE if verify_gradients else 0),
             P=Q.set_negate(self.exp_miller_loop[i] == -1),
             Q=T,
-            rolling_options=5,
+            rolling_options=boolean_list_to_bitmask([verify_gradients,False, True]),
         )  # Compute (2T ± Q)
         # stack in:     [P, Q, (2T ± Q)]
         # altstack in:  [({f_i^2} * ev_(l_(T,T))(P) * ev_(l_(2T, ± Q))(P))^2]
@@ -341,6 +341,7 @@ class MillerLoop:
         )
         # stack in:  [P, Q, T]
         # stack out: [w*Q, miller(P,Q)]
+        gradient_tracker = 0
         for i in range(len(self.exp_miller_loop) - 2, -1, -1):
             positive_modulo_i = positive_modulo if i == 0 else False
             clean_constant_i = clean_constant if i == 0 else False
@@ -396,34 +397,36 @@ class MillerLoop:
                 out += self.miller_loop_output_square(take_modulo=False, check_constant=False, clean_constant=False)
 
             if self.exp_miller_loop[i] == 0:
-                # stack in:  [gradient_(2T), P, Q, T, f_i^2]
-                # stack out: [P, Q, 2T, (f_i^2 * ev_(l_(T,T))(P))]
+                # stack in:  [gradient_(2T), ..., P, Q, T, f_i^2]
+                # stack out: [gradient_(2T) if not verify_gradients, ..., P, Q, 2T, (f_i^2 * ev_(l_(T,T))(P))]
                 out += self.__one_step_without_addition(
                     i=i,
                     take_modulo=[take_modulo_miller_loop_output, take_modulo_point_multiplication],
                     positive_modulo=positive_modulo_i,
                     verify_gradient=verify_gradients,
                     clean_constant=clean_constant_i,
-                    gradient_doubling=gradient_doubling,
+                    gradient_doubling=gradient_doubling.shift(gradient_tracker),
                     P=P,
                     T=T,
                 )
+                gradient_tracker += self.EXTENSION_DEGREE if not verify_gradients else 0
             else:
-                # stack in:  [gradient_(2T ± Q), gradient_(2T), P, Q, T, f_i^2]
-                # stack out: [P, Q, (2T ± Q), (f_i^2 * ev_(l_(T,T))(P) * ev_(l_(2T, ± Q))(P))]
+                # stack in:  [gradient_(2T ± Q), gradient_(2T), ..., P, Q, T, f_i^2]
+                # stack out: [gradient_(2T ± Q) in not verify_gradients, gradient_(2T) if not_verify_gradients, ..., P,
+                #               Q, (2T ± Q), (f_i^2 * ev_(l_(T,T))(P) * ev_(l_(2T, ± Q))(P))]
                 out += self.__one_step_with_addition(
                     i=i,
                     take_modulo=[take_modulo_miller_loop_output, take_modulo_point_multiplication],
                     positive_modulo=positive_modulo_i,
                     verify_gradients=verify_gradients,
                     clean_constant=clean_constant_i,
-                    gradient_doubling=gradient_doubling,
-                    gradient_addition=gradient_addition,
+                    gradient_doubling=gradient_doubling.shift(gradient_tracker),
+                    gradient_addition=gradient_addition.shift(gradient_tracker),
                     P=P,
                     Q=Q,
                     T=T,
                 )
-
+                gradient_tracker += 2*self.EXTENSION_DEGREE if not verify_gradients else 0
         # stack in:  [P, Q, w*Q, miller(P,Q)]
         # stack out: [w*Q, miller(P,Q)]
         out += move(Q.shift(self.N_ELEMENTS_MILLER_OUTPUT), roll)  # Roll Q

--- a/src/zkscript/bilinear_pairings/model/pairing.py
+++ b/src/zkscript/bilinear_pairings/model/pairing.py
@@ -2,6 +2,7 @@
 
 from tx_engine import Script
 
+from src.zkscript.types.stack_elements import StackFiniteFieldElement
 from src.zkscript.util.utility_functions import optimise_script
 from src.zkscript.util.utility_scripts import pick, roll, verify_bottom_constant
 
@@ -170,9 +171,21 @@ class Pairing:
             clean_constant=False,
         )
 
+        gradient_tracker = sum(
+            self.EXTENSION_DEGREE for verify_gradient in verify_gradients if not verify_gradient
+        ) * sum([1 if i == 0 else 2 for i in self.exp_miller_loop[:-1]])
+
         out += easy_exponentiation_with_inverse_check(
-            take_modulo=True, positive_modulo=False, check_constant=False, clean_constant=False
+            take_modulo=True,
+            positive_modulo=False,
+            check_constant=False,
+            clean_constant=False,
+            f=StackFiniteFieldElement(self.N_ELEMENTS_MILLER_OUTPUT - 1, False, self.N_ELEMENTS_MILLER_OUTPUT),
+            f_inverse=StackFiniteFieldElement(
+                2 * self.N_ELEMENTS_MILLER_OUTPUT - 1 + gradient_tracker, False, self.N_ELEMENTS_MILLER_OUTPUT
+            ),
         )
+
         out += hard_exponentiation(
             take_modulo=True,
             modulo_threshold=modulo_threshold,

--- a/src/zkscript/bilinear_pairings/model/pairing.py
+++ b/src/zkscript/bilinear_pairings/model/pairing.py
@@ -27,7 +27,7 @@ class Pairing:
             - altstack: []
 
         Stack output:
-            - stack:    [q, ..., lambdas if not verify_gradients, e(P,Q)],
+            - stack:    [q, ..., gradients if not verify_gradients, e(P,Q)],
             - altstack: []
 
         Args:
@@ -146,8 +146,8 @@ class Pairing:
             - altstack: []
 
         Stack output:
-            - stack:    [q, ..., non_verified_lambdas, e(P1,Q1) * e(P2,Q2) * e(P3,Q3)], non_verified_lambdas represents
-                all the gradients that are not verified by the script. Verified gradients are consumed.
+            - stack:    [q, ..., non_verified_gradients, e(P1,Q1) * e(P2,Q2) * e(P3,Q3)], `non_verified_gradients`
+                represents all the gradients that are not verified by the script. Verified gradients are consumed.
             - altstack: []
 
         Args:

--- a/src/zkscript/bilinear_pairings/model/pairing.py
+++ b/src/zkscript/bilinear_pairings/model/pairing.py
@@ -81,7 +81,9 @@ class Pairing:
             clean_constant=False,
         )
 
-        gradient_tracker = (0 if verify_gradients else self.EXTENSION_DEGREE) * sum([1 if i == 0 else 2 for i in self.exp_miller_loop[:-1]])
+        gradient_tracker = (0 if verify_gradients else self.EXTENSION_DEGREE) * sum(
+            [1 if i == 0 else 2 for i in self.exp_miller_loop[:-1]]
+        )
 
         # This is where one would perform subgroup membership checks if they were needed
         # For Groth16, they are not, so we simply drop uQ
@@ -89,7 +91,10 @@ class Pairing:
         out += Script.parse_string(" ".join(["OP_DROP"] * N_POINTS_TWIST))
 
         out += easy_exponentiation_with_inverse_check(
-            take_modulo=True, positive_modulo=False, check_constant=False, clean_constant=False, 
+            take_modulo=True,
+            positive_modulo=False,
+            check_constant=False,
+            clean_constant=False,
             f_inverse=StackFiniteFieldElement(
                 2 * self.N_ELEMENTS_MILLER_OUTPUT - 1, False, self.N_ELEMENTS_MILLER_OUTPUT
             ).shift(gradient_tracker),

--- a/src/zkscript/bilinear_pairings/model/triple_miller_loop.py
+++ b/src/zkscript/bilinear_pairings/model/triple_miller_loop.py
@@ -443,7 +443,7 @@ class TripleMillerLoop:
         # stack in:     [..., gradient_(2* T2 ± Q2), gradient_(2* T3 ± Q3), ...,
         #                   gradient_(2*T3), P1, P2, P3, Q1, Q2, Q3, T3, (2*T1 ± Q1), (2*T2)]
         # altstack in:  [{f_i^2}*(ev_(l_(T1,T1))(P1)*ev_(l_(T2,T2))(P2)) *(ev_(l_(T3,T3))(P3)*ev_(l_(2*T1,± Q1))(P1)) * (ev_(l_(2*T2,± Q2))(P2)*ev_(l_(2*T3,± Q3))(P3))]  # noqa: E501
-        # stack out:    [..., gradient_(2* T2 ± Q2) if not verify_gradient[1], gradient_(2* T3 ± Q3), ..., 
+        # stack out:    [..., gradient_(2* T2 ± Q2) if not verify_gradient[1], gradient_(2* T3 ± Q3), ...,
         #                   gradient_(2*T3), P1, P2, P3, Q1, Q2, Q3, T3, (2*T1 ± Q1), (2*T2 ± Q2)]
         # altstack out: [{f_i^2}*(ev_(l_(T1,T1))(P1)*ev_(l_(T2,T2))(P2)) *(ev_(l_(T3,T3))(P3)*ev_(l_(2*T1,± Q1))(P1)) * (ev_(l_(2*T2,± Q2))(P2)*ev_(l_(2*T3,± Q3))(P3))]  # noqa: E501
         out += self.point_addition_twisted_curve(
@@ -457,7 +457,7 @@ class TripleMillerLoop:
             Q=T[1].shift(-self.N_POINTS_TWIST),
             rolling_options=boolean_list_to_bitmask([verify_gradients[1], False, True]),
         )
-        # stack in:     [..., gradient_(2* T3 ± Q3), ..., gradient_(2*T3), P1, P2, P3, Q1, Q2, Q3, T3, (2*T1 ± Q1), 
+        # stack in:     [..., gradient_(2* T3 ± Q3), ..., gradient_(2*T3), P1, P2, P3, Q1, Q2, Q3, T3, (2*T1 ± Q1),
         #                   (2*T2 ± Q2)]
         # altstack in:  [{f_i^2}*(ev_(l_(T1,T1))(P1)*ev_(l_(T2,T2))(P2)) *(ev_(l_(T3,T3))(P3)*ev_(l_(2*T1,± Q1))(P1)) * (ev_(l_(2*T2,± Q2))(P2)*ev_(l_(2*T3,± Q3))(P3))]  # noqa: E501
         # stack out:    [..., gradient_(2* T3 ± Q3), ..., gradient_(2*T3) if not verify_gradient[2], P1, P2, P3, Q1, Q2,

--- a/src/zkscript/bilinear_pairings/model/triple_miller_loop.py
+++ b/src/zkscript/bilinear_pairings/model/triple_miller_loop.py
@@ -404,7 +404,6 @@ class TripleMillerLoop:
             rolling_options=boolean_list_to_bitmask([verify_gradients[0], True]),
         )  # Compute 2 * T1
         verify_gradient_shift = self.EXTENSION_DEGREE if verify_gradients[0] else 0
-        # out += Script.parse_string("OP_0 OP_1 OP_EQUALVERIFY")
         # stack in:     [gradient_(2* T1 ± Q1), gradient_(2* T2 ± Q2), gradient_(2* T3 ± Q3),
         #                   gradient_(2*T2), gradient_(2*T3), P1, P2, P3, Q1, Q2, Q3, T2, T3, 2*T1]
         # altstack in:  [{f_i^2}*(ev_(l_(T1,T1))(P1)*ev_(l_(T2,T2))(P2)) *(ev_(l_(T3,T3))(P3)*ev_(l_(2*T1,± Q1))(P1)) * (ev_(l_(2*T2,± Q2))(P2)*ev_(l_(2*T3,± Q3))(P3))]  # noqa: E501
@@ -490,7 +489,6 @@ class TripleMillerLoop:
             Q=T[2],
             rolling_options=boolean_list_to_bitmask([verify_gradients[2], False, True]),
         )
-        # out += Script.parse_string("OP_0 OP_1 OP_EQUALVERIFY")
         # stack in:     [..., P1, P2, P3, Q1, Q2, Q3, (2*T1 ± Q1), (2*T2 ± Q2), (2*T3 ± Q3)]
         # altstack in:  [{f_i^2}*(ev_(l_(T1,T1))(P1)*ev_(l_(T2,T2))(P2)) *(ev_(l_(T3,T3))(P3)*ev_(l_(2*T1,± Q1))(P1)) * (ev_(l_(2*T2,± Q2))(P2)*ev_(l_(2*T3,± Q3))(P3))]  # noqa: E501
         # stack out:    [..., P1, P2, P3, Q1, Q2, Q3, (2*T1 ± Q1), (2*T2 ± Q2), (2*T3 ± Q3),

--- a/src/zkscript/groth16/model/groth16.py
+++ b/src/zkscript/groth16/model/groth16.py
@@ -45,7 +45,7 @@ class Groth16(PairingModel):
         verification_hash = b""
         for i in range(len(locking_key.gradients_pairings[0])):
             for j in range(len(locking_key.gradients_pairings[0][i])):
-                for k in range(2,0,-1):
+                for k in range(2, 0, -1):
                     for s in range(self.pairing_model.EXTENSION_DEGREE - 1, -1, -1):
                         verification_hash = encode_num(locking_key.gradients_pairings[k][i][j][s]) + verification_hash
                         verification_hash = hash256d(verification_hash)

--- a/src/zkscript/groth16/model/groth16.py
+++ b/src/zkscript/groth16/model/groth16.py
@@ -58,7 +58,7 @@ class Groth16(PairingModel):
             - stack: [.., gradients_pairing]
 
         Stack output:
-            - stack: [.., ] or fail
+            - stack: [.., 0/1]
 
         Args:
             locking_key (Groth16LockingKey): Locking key used to generate the verifier. Encapsulates the data of the
@@ -209,9 +209,9 @@ class Groth16(PairingModel):
             out += nums_to_script([el])
             out += Script.parse_string("OP_EQUALVERIFY")
 
-        # Verify that the gradients supplied for -gamma and -delta are the correct one
+        # Verify that the gradients supplied for -gamma and -delta are the correct ones
         # stack in:  [q, ..., gradients_pairing]
-        # stack out: [q, ...] or fail
+        # stack out: [q, ..., 0/1]
         out += self.__verify_hash_commitment(locking_key=locking_key, verification_hash=verification_hash)
 
         return optimise_script(out)

--- a/src/zkscript/merkle_tree/merkle_tree.py
+++ b/src/zkscript/merkle_tree/merkle_tree.py
@@ -51,7 +51,7 @@ class MerkleTree:
 
         Args:
             is_equal_verify (bool): If `True`, use `OP_EQUALVERIFY` in the final verification step, otherwise
-                `OP_EQUAL`. Default to `False`.
+                `OP_EQUAL`. Defaults to `False`.
 
         Returns:
             Locking script for verifying a Merkle path using a bit flag to identify right and left nodes.


### PR DESCRIPTION
Changes include:
- postpone gradient verification in Groth16
- change triple Miller loop to support delayed gradient verification
- change easy exponentiation to be compatible with the updated triple Miller loop